### PR TITLE
Add PDF export progress and status bar indication via Lumino signals and a frontend plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Github Actions build status](https://github.com/agriyakhetarpal/jupyterlite-pandoc-pdf-exporter/workflows/Build/badge.svg)](https://github.com/agriyakhetarpal/jupyterlite-pandoc-pdf-exporter/actions/workflows/build.yml)
 [![Try PDF exporter in JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://agriyakhetarp.al/jupyterlite-pandoc-pdf-exporter/)
 
-A serverless PDF exporter for JupyterLite based on WebAssembly distributions of Pandoc and Typst. This mono-plugin extension registers a
+A serverless PDF exporter for JupyterLite based on WebAssembly distributions of Pandoc and Typst. This JupyterLite extension registers a
 PDF exporter with [JupyterLite's `INbConvertExporters` interface](https://jupyterlite.readthedocs.io/en/stable/howto/extensions/custom-exporters.html).
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
+        "@jupyterlab/application": "^4.5.4",
         "@jupyterlab/services": "^7.5.4",
+        "@jupyterlab/statusbar": "^4.5.4",
         "@jupyterlite/services": "^0.7.1",
         "@myriaddreamin/typst-all-in-one.ts": "0.7.0-rc2",
         "pandoc-wasm": "1.0.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,15 @@ import { INbConvertExporters } from '@jupyterlite/services';
 
 import { PdfExporter } from './pdf';
 
+import { statusBarPlugin } from './status';
+
 /**
  * A ServiceManagerPlugin for JupyterLite that registers a PDF exporter based
  * on WebAssembly distributions of Pandoc and Typst. This uses the INbConvertExporters
  * token to register the exporter, which allows it to be shown in JupyterLite's export
  * menu and subsequently in the "File" menu > "Save and Export Notebook As" dropdown.
  */
-const plugin: ServiceManagerPlugin<void> = {
+const exporterPlugin: ServiceManagerPlugin<void> = {
   id: 'jupyterlite-pandoc-pdf-exporter:plugin',
   description:
     'A PDF exporter for JupyterLite based on WebAssembly distributions of Pandoc and Typst',
@@ -24,4 +26,4 @@ const plugin: ServiceManagerPlugin<void> = {
   }
 };
 
-export default plugin;
+export default [exporterPlugin, statusBarPlugin];

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Agriya Khetarpal
+// SPDX-License-Identifier: BSD-3-Clause
+
+import { ISignal, Signal } from '@lumino/signaling';
+
+/**
+ * This is a singleton class that manages the state of PDF export progress,
+ * which we use to communicate progress updates from the PdfExporter to the
+ * status bar widget.
+ */
+class PdfExportProgress {
+  get progressChanged(): ISignal<this, string> {
+    return this._progressChanged;
+  }
+
+  get activeStateChanged(): ISignal<this, void> {
+    return this._activeStateChanged;
+  }
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  get message(): string {
+    return this._message;
+  }
+
+  start(message: string): void {
+    if (this._hideTimeout !== null) {
+      clearTimeout(this._hideTimeout);
+      this._hideTimeout = null;
+    }
+    this._isActive = true;
+    this._message = message;
+    this._activeStateChanged.emit(void 0);
+    this._progressChanged.emit(message);
+  }
+
+  update(message: string): void {
+    this._message = message;
+    this._progressChanged.emit(message);
+  }
+
+  finish(message: string, hideDelayMs = 3000): void {
+    this._message = message;
+    this._progressChanged.emit(message);
+
+    this._hideTimeout = window.setTimeout(() => {
+      this._isActive = false;
+      this._message = '';
+      this._hideTimeout = null;
+      this._activeStateChanged.emit(void 0);
+    }, hideDelayMs);
+  }
+
+  private _isActive = false;
+  private _message = '';
+  private _hideTimeout: number | null = null;
+  private _progressChanged = new Signal<this, string>(this);
+  private _activeStateChanged = new Signal<this, void>(this);
+}
+
+export const pdfExportProgress = new PdfExportProgress();

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Agriya Khetarpal
+// SPDX-License-Identifier: BSD-3-Clause
+
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { IStatusBar } from '@jupyterlab/statusbar';
+
+import { Widget } from '@lumino/widgets';
+
+import { pdfExportProgress } from './progress';
+
+/**
+ * This is a Lumino widget that listens to the pdfExportProgress singleton for updates and displays
+ * related to PDF export progress and displays them in the centre of the status bar. It is registered as a status bar item in the statusBarPlugin below.
+ */
+class PdfExportStatusWidget extends Widget {
+  constructor() {
+    super();
+    this.node.classList.add('jp-StatusBar-TextItem');
+    pdfExportProgress.progressChanged.connect(this._onProgressChanged, this);
+  }
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    pdfExportProgress.progressChanged.disconnect(this._onProgressChanged, this);
+    super.dispose();
+  }
+
+  private _onProgressChanged(_sender: unknown, message: string): void {
+    this.node.textContent = message;
+  }
+}
+
+/**
+ * A JupyterFrontEndPlugin that registers a status bar item
+ * for PDF export progress.
+ */
+export const statusBarPlugin: JupyterFrontEndPlugin<void> = {
+  id: 'jupyterlite-pandoc-pdf-exporter:status-bar',
+  description: 'A status bar progress indicator for PDF export',
+  autoStart: true,
+  optional: [IStatusBar],
+  activate: (_app: JupyterFrontEnd, statusBar: IStatusBar | null): void => {
+    if (!statusBar) {
+      return;
+    }
+
+    const widget = new PdfExportStatusWidget();
+
+    statusBar.registerStatusItem('jupyterlite-pandoc-pdf-exporter:status-bar', {
+      item: widget,
+      align: 'middle',
+      isActive: () => pdfExportProgress.isActive,
+      activeStateChanged: pdfExportProgress.activeStateChanged
+    });
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7701,8 +7701,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jupyterlite-pandoc-pdf-exporter@workspace:."
   dependencies:
+    "@jupyterlab/application": ^4.5.4
     "@jupyterlab/builder": ^4.5.4
     "@jupyterlab/services": ^7.5.4
+    "@jupyterlab/statusbar": ^4.5.4
     "@jupyterlab/testutils": ^4.5.4
     "@jupyterlite/services": ^0.7.1
     "@myriaddreamin/typst-all-in-one.ts": 0.7.0-rc2


### PR DESCRIPTION
This PR introduces a `pdfExportProgress` class and a status bar plugin so that we can surface PDF export progress with messages of when we are preparing the export (where Pandoc and Typst are loaded), when conversion starts, when the PDF is generated, and lastly a "PDF exported successfully" (or a failed response). `src/progress.ts` is where we keep the `PdfExportProgress` singleton, and `src/status.ts` is where we have a `PdfExportStatusWidget` and a `statusBarPlugin`.

See #12. This is a hybrid of approaches 1 and 3, in that we didn't inject anything into the `PdfExporter` and the signal lives on a dedicated singleton object rather than on `PdfExporter` itself (otherwise we would have required making `PdfExporter` a `Lumino` object to own a `Signal`). I will leave the issue open for myself to explore how we could simplify this further later on.