### PR TITLE
Add a settings schema and related plugins to customise PDF outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ htmlcov/
 nosetests.xml
 coverage/
 coverage.xml
+junit.xml
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# `jupyterlite-pdf-exporter`, version 0.1.0
+# `jupyterlite-pdf-exporter`
 
 [![Github Actions build status](https://github.com/agriyakhetarpal/jupyterlite-pdf-exporter/workflows/Build/badge.svg)](https://github.com/agriyakhetarpal/jupyterlite-pdf-exporter/actions/workflows/build.yml)
 [![Try PDF exporter in JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://agriyakhetarp.al/jupyterlite-pdf-exporter/)
+[![PyPI version](https://badge.fury.io/py/jupyterlite-pdf-exporter.svg)](https://pypi.org/project/jupyterlite-pdf-exporter/)
 
 A serverless PDF exporter for JupyterLite based on WebAssembly distributions of [Pandoc](https://pandoc.org/app) and [Typst](https://typst.org/). This JupyterLite extension registers a
 PDF exporter with [JupyterLite's `INbConvertExporters` interface](https://jupyterlite.readthedocs.io/en/stable/howto/extensions/custom-exporters.html).

--- a/README.md
+++ b/README.md
@@ -6,17 +6,6 @@
 A serverless PDF exporter for JupyterLite based on WebAssembly distributions of [Pandoc](https://pandoc.org/app) and [Typst](https://typst.org/). This JupyterLite extension registers a
 PDF exporter with [JupyterLite's `INbConvertExporters` interface](https://jupyterlite.readthedocs.io/en/stable/howto/extensions/custom-exporters.html).
 
-## Usage
-
-- Install this extension in your JupyterLite deployment via `pip install jupyterlite-pdf-exporter` and rebuild your JupyterLite distribution.
-- Open a notebook in JupyterLite, click on the "File" menu, and select "Save and Export Notebook As" > "PDF". The PDF file will be downloaded to your local machine at a location of your choice.
-
-## Requirements
-
-- JupyterLite 0.7.0 and later
-- A modern web browser with support for WebAssembly and Web Workers (e.g., Chrome, Firefox, Safari, Edge, and so on). All browsers supported by JupyterLite should work with this extension.
-- The extension relies on WebAssembly distributions of Pandoc and Typst. These distributions are quite large (over 50 MiB) and may take some time to download and initialise when the extension is first used. For a better user experience, it is recommended to use this extension in an environment with a stable and reasonably fast internet connection.
-
 ## Installation
 
 To install the extension into your JupyterLite deployment, execute:
@@ -36,6 +25,90 @@ pip uninstall jupyterlite-pdf-exporter
 ```
 
 and rebuild your JupyterLite distribution.
+
+## Usage
+
+- Install this extension in your JupyterLite deployment via `pip install jupyterlite-pdf-exporter` and rebuild your JupyterLite distribution.
+- Open a notebook in JupyterLite, click on the "File" menu, and select "Save and Export Notebook As" > "PDF". The PDF file will be downloaded to your local machine at a location of your choice.
+
+### Requirements
+
+- JupyterLite 0.7.0 and later
+- A modern web browser with support for WebAssembly and Web Workers (e.g., Chrome, Firefox, Safari, Edge, and so on). All browsers supported by JupyterLite should work with this extension.
+- The extension relies on WebAssembly distributions of Pandoc and Typst. These distributions are quite large (over 50 MiB) and may take some time to download and initialise when the extension is first used. For a better user experience, it is recommended to use this extension in an environment with a stable and reasonably fast internet connection.
+
+### Customising the PDFs
+
+It is also possible to change the look and feel of the exported PDF(s) through the settings.
+
+To change the settings for yourself, open the "Settings Editor" in JupyterLite from the "Settings" menu and pick "JupyterLite PDF Exporter". The form lets you set the page size, font, margins, and more. The new settings apply the next time you export a notebook. Choosing the settings per-notebook is currently not implemented.
+
+If you build a JupyterLite site for other people, you can set the defaults for everyone. For this, you may add an entry for `jupyterlite-pdf-exporter:plugin` to an `overrides.json` file in your build, or to the `settingsOverrides` field in your `jupyter-lite.json` file. Those values become the starting point for every user, who can still change them in their own Settings Editor.
+
+Only the fonts that come bundled with the Typst compiler are available.
+
+Here is a table of what each setting changes. The "Key" column is the name you write in `overrides.json` or in `settingsOverrides`. The "Pandoc mapping" column shows where the value ends up. a "variable" is passed as a [Pandoc template variable](https://pandoc.org/MANUAL.html#variables) and an "option" is a top-level [Pandoc option](https://pandoc.org/MANUAL.html#general-options). You do not need to know these to use the settings, but they are handy if you want to read the Pandoc and Typst docs.
+
+| Setting           | Key               | What it does                               | Pandoc mapping             | Example value(s)     |
+| ----------------- | ----------------- | ------------------------------------------ | -------------------------- | -------------------- |
+| Page size         | `pageSize`        | Sets the paper size of the PDF             | variable `papersize`       | `a4`, `us-letter`    |
+| Font size         | `fontSize`        | Sets the base text size                    | variable `fontsize`        | `10pt`, `12pt`       |
+| Margins           | `margin`          | Sets the space around the page edges       | variable `margin`          | `{ "top": "2.5cm" }` |
+| Main font         | `mainFont`        | Picks the body font from the bundled fonts | variable `mainfont`        | `Libertinus Serif`   |
+| Page numbers      | `pageNumbers`     | Turns page numbers on or off               | variable `page-numbering`  | `true` (default)     |
+| Table of contents | `tableOfContents` | Adds a contents list at the start          | option `table-of-contents` | `false` (default)    |
+| Number sections   | `numberSections`  | Adds numbers to headings                   | option `number-sections`   | `false` (default)    |
+| Line spacing      | `lineSpacing`     | Sets the spacing between lines             | variable `linestretch`     | `1` (default), `1.5` |
+| Link color        | `linkColor`       | Sets the colour used for links             | variable `linkcolor`       | `#0F4C81`            |
+
+The `margin` key takes an object with any of `top`, `bottom`, `left`, and `right`, for example `{ "top": "2.5cm", "bottom": "2.5cm", "left": "2cm", "right": "2cm" }`.
+
+For `linkColor`, the Settings Editor shows a colour picker for ease of use. In `overrides.json` or `jupyter-lite.json`, you can use a HEX value such as `#0F4C81` (with or without the `#`). An invalid value fails the PDF export.
+
+#### An example deployment configuration
+
+Each key goes under the plugin ID `jupyterlite-pdf-exporter:plugin`. Here is a full `overrides.json` that you can drop into your JupyterLite build folder:
+
+```json
+{
+  "jupyterlite-pdf-exporter:plugin": {
+    "pageSize": "us-letter",
+    "mainFont": "New Computer Modern",
+    "pageNumbers": false,
+    "tableOfContents": true,
+    "numberSections": true,
+    "lineSpacing": 1.15,
+    "linkColor": "#0F4C81",
+    "margin": {
+      "top": "3cm",
+      "bottom": "3cm",
+      "left": "2.5cm",
+      "right": "2.5cm"
+    }
+  }
+}
+```
+
+The same values can instead live under `settingsOverrides` in your `jupyter-lite.json` as well:
+
+```json
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "settingsOverrides": {
+      "jupyterlite-pdf-exporter:plugin": {
+        "pageSize": "us-letter",
+        "pageNumbers": false
+      }
+    }
+  }
+}
+```
+
+For further reference, navigate to the following resources:
+
+1. [JupyterLite documentation on configuration files](https://jupyterlite.readthedocs.io/en/stable/howto/configure/config_files.html)
+2. [JupyterLite documentation on settings overrides](https://jupyterlite.readthedocs.io/en/stable/howto/configure/settings.html)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you build a JupyterLite site for other people, you can set the defaults for e
 
 Only the fonts that come bundled with the Typst compiler are available.
 
-Here is a table of what each setting changes. The "Key" column is the name you write in `overrides.json` or in `settingsOverrides`. The "Pandoc mapping" column shows where the value ends up. a "variable" is passed as a [Pandoc template variable](https://pandoc.org/MANUAL.html#variables) and an "option" is a top-level [Pandoc option](https://pandoc.org/MANUAL.html#general-options). You do not need to know these to use the settings, but they are handy if you want to read the Pandoc and Typst docs.
+Here is a table of what each setting changes. The "Key" column is the name you write in `overrides.json` or in `settingsOverrides`. The "Pandoc mapping" column shows where the value ends up. A "variable" is passed as a [Pandoc template variable](https://pandoc.org/MANUAL.html#variables) and an "option" is a top-level [Pandoc option](https://pandoc.org/MANUAL.html#general-options). You do not need to know these to use the settings, but they are handy if you want to read the Pandoc and Typst docs.
 
 | Setting           | Key               | What it does                               | Pandoc mapping             | Example value(s)     |
 | ----------------- | ----------------- | ------------------------------------------ | -------------------------- | -------------------- |

--- a/package.json
+++ b/package.json
@@ -64,17 +64,17 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
-        "@jupyterlab/application": "^4.5.6",
-        "@jupyterlab/services": "^7.5.6",
-        "@jupyterlab/settingregistry": "^4.5.6",
-        "@jupyterlab/statusbar": "^4.5.6",
-        "@jupyterlite/services": "^0.7.4",
+        "@jupyterlab/application": "^4.5.8",
+        "@jupyterlab/services": "^7.5.8",
+        "@jupyterlab/settingregistry": "^4.5.8",
+        "@jupyterlab/statusbar": "^4.5.8",
+        "@jupyterlite/services": "^0.7.6",
         "@myriaddreamin/typst-all-in-one.ts": "0.7.0-rc2",
         "pandoc-wasm": "1.0.1"
     },
     "devDependencies": {
-        "@jupyterlab/builder": "^4.5.6",
-        "@jupyterlab/testutils": "^4.5.6",
+        "@jupyterlab/builder": "^4.5.8",
+        "@jupyterlab/testutils": "^4.5.8",
         "@types/emscripten": "^1.41.5",
         "@types/jest": "^30.0.0",
         "@types/json-schema": "^7.0.15",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "dependencies": {
         "@jupyterlab/application": "^4.5.6",
         "@jupyterlab/services": "^7.5.6",
+        "@jupyterlab/settingregistry": "^4.5.6",
         "@jupyterlab/statusbar": "^4.5.6",
         "@jupyterlite/services": "^0.7.4",
         "@myriaddreamin/typst-all-in-one.ts": "0.7.0-rc2",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "jupyterlab": {
         "extension": true,
         "outputDir": "jupyterlite_pdf_exporter/labextension",
+        "schemaDir": "schema",
         "webpackConfig": "./webpack.config.js",
         "sharedPackages": {
             "@jupyterlite/services": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlite-pdf-exporter",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "A PDF exporter for JupyterLite based on WebAssembly distributions of Pandoc and Typst.",
     "keywords": [
         "jupyter",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,6 +1,8 @@
 {
   "jupyter.lab.shortcuts": [],
-  "title": "jupyterlite-pdf-exporter",
+  "jupyter.lab.setting-icon": "ui-components:pdf",
+  "jupyter.lab.setting-icon-label": "JupyterLite PDF Exporter",
+  "title": "JupyterLite PDF Exporter",
   "description": "Settings for the JupyterLite PDF exporter. These control the look and feel of the exported PDFs via Pandoc template variable mappings.",
   "type": "object",
   "properties": {

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,8 +1,78 @@
 {
   "jupyter.lab.shortcuts": [],
   "title": "jupyterlite-pdf-exporter",
-  "description": "jupyterlite-pdf-exporter settings.",
+  "description": "Settings for the JupyterLite PDF exporter. These control the look and feel of the exported PDFs via Pandoc template variable mappings.",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "pageSize": {
+      "title": "Page size",
+      "description": "The paper size of the exported PDF.",
+      "type": "string",
+      "enum": ["a4", "us-letter", "a3", "a5"],
+      "default": "a4"
+    },
+    "fontSize": {
+      "title": "Font size",
+      "description": "The base text size. Include the unit, for example \"10pt\" or \"12pt\". Leave empty to use the default.",
+      "type": "string",
+      "default": "10pt"
+    },
+    "margin": {
+      "title": "Margins",
+      "description": "The space around the page edges. Include the unit, for example \"2cm\". Leave a field empty to use the default for that side.",
+      "type": "object",
+      "properties": {
+        "top": { "title": "Top", "type": "string", "default": "2.5cm" },
+        "bottom": { "title": "Bottom", "type": "string", "default": "2.5cm" },
+        "left": { "title": "Left", "type": "string", "default": "2cm" },
+        "right": { "title": "Right", "type": "string", "default": "2cm" }
+      },
+      "additionalProperties": false,
+      "default": {
+        "top": "2.5cm",
+        "bottom": "2.5cm",
+        "left": "2cm",
+        "right": "2cm"
+      }
+    },
+    "mainFont": {
+      "title": "Main font",
+      "description": "The body font. Only fonts bundled with the Typst compiler are available.",
+      "type": "string",
+      "enum": ["Libertinus Serif", "New Computer Modern", "DejaVu Sans Mono"],
+      "default": "Libertinus Serif"
+    },
+    "pageNumbers": {
+      "title": "Page numbers",
+      "description": "Whether to print page numbers in the footer.",
+      "type": "boolean",
+      "default": true
+    },
+    "tableOfContents": {
+      "title": "Table of contents",
+      "description": "Add a table of contents at the start of the document.",
+      "type": "boolean",
+      "default": false
+    },
+    "numberSections": {
+      "title": "Number sections",
+      "description": "Add numbers to section headings.",
+      "type": "boolean",
+      "default": false
+    },
+    "lineSpacing": {
+      "title": "Line spacing",
+      "description": "The spacing between lines, as a multiple of the normal spacing.",
+      "type": "number",
+      "minimum": 0.5,
+      "default": 1
+    },
+    "linkColor": {
+      "title": "Link color",
+      "description": "The color used for links, for example \"blue\" or \"#1a73e8\". Leave empty to use the default.",
+      "type": "string",
+      "default": ""
+    }
+  },
   "additionalProperties": false
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -69,9 +69,10 @@
     },
     "linkColor": {
       "title": "Link color",
-      "description": "The color used for links, for example \"blue\" or \"#1a73e8\". Leave empty to use the default.",
+      "description": "The color used for links, shown as a color picker. In a configuration file, you can write a HEX value like \"#1a73e8\". Defaults to the classic link blue (#0000ee).",
       "type": "string",
-      "default": ""
+      "format": "color",
+      "default": "#0000ee"
     }
   },
   "additionalProperties": false

--- a/src/__tests__/jupyterlite_pdf_exporter.spec.ts
+++ b/src/__tests__/jupyterlite_pdf_exporter.spec.ts
@@ -120,6 +120,10 @@ describe('buildPandocConfig', () => {
 });
 
 describe('pdfExportSettings', () => {
+  beforeEach(() => {
+    pdfExportSettings.update(undefined);
+  });
+
   it('falls back to defaults for missing keys', () => {
     pdfExportSettings.update({ pageSize: 'a3' });
     expect(pdfExportSettings.current.pageSize).toBe('a3');

--- a/src/__tests__/jupyterlite_pdf_exporter.spec.ts
+++ b/src/__tests__/jupyterlite_pdf_exporter.spec.ts
@@ -86,6 +86,22 @@ describe('buildPandocConfig', () => {
     expect(variables.linkcolor).toBeUndefined();
   });
 
+  it('strips a leading "#" from a hex link color', () => {
+    const { variables } = buildPandocConfig({
+      ...baseSettings,
+      linkColor: '#1a73e8'
+    });
+    expect(variables.linkcolor).toBe('1a73e8');
+  });
+
+  it('accepts a hex link color without a leading "#"', () => {
+    const { variables } = buildPandocConfig({
+      ...baseSettings,
+      linkColor: 'ff0000'
+    });
+    expect(variables.linkcolor).toBe('ff0000');
+  });
+
   it('sets table of contents and number sections as top-level options', () => {
     const { options } = buildPandocConfig({
       ...baseSettings,

--- a/src/__tests__/jupyterlite_pdf_exporter.spec.ts
+++ b/src/__tests__/jupyterlite_pdf_exporter.spec.ts
@@ -1,9 +1,121 @@
-/**
- * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
- */
+import {
+  buildPandocConfig,
+  IPdfExportSettings,
+  pdfExportSettings
+} from '../settings';
 
-describe('jupyterlite-pdf-exporter', () => {
-  it('should be tested', () => {
-    expect(1 + 1).toEqual(2);
+const baseSettings: IPdfExportSettings = {
+  pageSize: 'a4',
+  fontSize: '10pt',
+  margin: {
+    top: '2.5cm',
+    bottom: '2.5cm',
+    left: '2cm',
+    right: '2cm'
+  },
+  mainFont: 'Libertinus Serif',
+  pageNumbers: true,
+  tableOfContents: false,
+  numberSections: false,
+  lineSpacing: 1,
+  linkColor: ''
+};
+
+describe('buildPandocConfig', () => {
+  it('maps the curated settings to pandoc variables', () => {
+    const { variables } = buildPandocConfig({
+      ...baseSettings,
+      pageSize: 'us-letter',
+      fontSize: '12pt',
+      mainFont: 'New Computer Modern'
+    });
+    expect(variables.papersize).toBe('us-letter');
+    expect(variables.fontsize).toBe('12pt');
+    expect(variables.mainfont).toBe('New Computer Modern');
+  });
+
+  it('builds the margin map from the four sides', () => {
+    const { variables } = buildPandocConfig(baseSettings);
+    expect(variables.margin).toEqual({
+      top: '2.5cm',
+      bottom: '2.5cm',
+      left: '2cm',
+      right: '2cm'
+    });
+  });
+
+  it('omits margin sides that are empty', () => {
+    const { variables } = buildPandocConfig({
+      ...baseSettings,
+      margin: { top: '3cm', bottom: '', left: '', right: '' }
+    });
+    expect(variables.margin).toEqual({ top: '3cm' });
+  });
+
+  it('keeps page numbers on by default with "1"', () => {
+    const { variables } = buildPandocConfig({
+      ...baseSettings,
+      pageNumbers: true
+    });
+    expect(variables['page-numbering']).toBe('1');
+  });
+
+  it('turns page numbers off with an empty value', () => {
+    const { variables } = buildPandocConfig({
+      ...baseSettings,
+      pageNumbers: false
+    });
+    expect(variables['page-numbering']).toBe('');
+  });
+
+  it('omits line spacing when it is the default of 1', () => {
+    const { variables } = buildPandocConfig(baseSettings);
+    expect(variables.linestretch).toBeUndefined();
+  });
+
+  it('includes line spacing when it differs from 1', () => {
+    const { variables } = buildPandocConfig({
+      ...baseSettings,
+      lineSpacing: 1.5
+    });
+    expect(variables.linestretch).toBe(1.5);
+  });
+
+  it('omits link color when it is empty', () => {
+    const { variables } = buildPandocConfig(baseSettings);
+    expect(variables.linkcolor).toBeUndefined();
+  });
+
+  it('sets table of contents and number sections as top-level options', () => {
+    const { options } = buildPandocConfig({
+      ...baseSettings,
+      tableOfContents: true,
+      numberSections: true
+    });
+    expect(options['table-of-contents']).toBe(true);
+    expect(options['number-sections']).toBe(true);
+  });
+
+  it('omits the toggle options when they are off', () => {
+    const { options } = buildPandocConfig(baseSettings);
+    expect(options['table-of-contents']).toBeUndefined();
+    expect(options['number-sections']).toBeUndefined();
+  });
+});
+
+describe('pdfExportSettings', () => {
+  it('falls back to defaults for missing keys', () => {
+    pdfExportSettings.update({ pageSize: 'a3' });
+    expect(pdfExportSettings.current.pageSize).toBe('a3');
+    expect(pdfExportSettings.current.mainFont).toBe('Libertinus Serif');
+    expect(pdfExportSettings.current.margin.left).toBe('2cm');
+  });
+
+  it('merges a partial margin over the default margin', () => {
+    pdfExportSettings.update({
+      margin: { top: '5cm' } as IPdfExportSettings['margin']
+    });
+    expect(pdfExportSettings.current.margin.top).toBe('5cm');
+    expect(pdfExportSettings.current.margin.bottom).toBe('2.5cm');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { PdfExporter } from './pdf';
 
 import { statusBarPlugin } from './status';
 
-import { settingsPlugin } from './settings';
+import { settingsPlugin } from './settings-plugin';
 
 /**
  * A ServiceManagerPlugin for JupyterLite that registers a PDF exporter based

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { PdfExporter } from './pdf';
 
 import { statusBarPlugin } from './status';
 
+import { settingsPlugin } from './settings';
+
 /**
  * A ServiceManagerPlugin for JupyterLite that registers a PDF exporter based
  * on WebAssembly distributions of Pandoc and Typst. This uses the INbConvertExporters
@@ -26,4 +28,4 @@ const exporterPlugin: ServiceManagerPlugin<void> = {
   }
 };
 
-export default [exporterPlugin, statusBarPlugin];
+export default [exporterPlugin, statusBarPlugin, settingsPlugin];

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -7,6 +7,8 @@ import { BaseExporter } from '@jupyterlite/services';
 
 import { pdfExportProgress } from './progress';
 
+import { buildPandocConfig, pdfExportSettings } from './settings';
+
 // Typst compiler creates a global $typst
 declare const $typst: {
   resetShadow: () => void;
@@ -63,13 +65,19 @@ export class PdfExporter extends BaseExporter {
         'notebook.ipynb': notebookJson
       };
 
+      const { options, variables } = buildPandocConfig(
+        pdfExportSettings.current
+      );
+
       const result = await pandocConvert!(
         {
           from: 'ipynb',
           to: 'typst',
           standalone: true,
           'extract-media': '.',
-          'input-files': ['notebook.ipynb']
+          'input-files': ['notebook.ipynb'],
+          ...options,
+          variables
         },
         null,
         files

--- a/src/settings-plugin.ts
+++ b/src/settings-plugin.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Agriya Khetarpal
+// SPDX-License-Identifier: BSD-3-Clause
+
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
+import { IPdfExportSettings, pdfExportSettings } from './settings';
+
+/**
+ * The plugin ID whose schema (see schema/plugin.json) holds the PDF export
+ * settings. It matches the ID of the exporter plugin in index.ts.
+ */
+const PLUGIN_ID = 'jupyterlite-pdf-exporter:plugin';
+
+/**
+ * A JupyterFrontEndPlugin that loads the PDF export settings from the settings
+ * registry and keeps the `pdfExportSettings` singleton in sync. We use this as
+ * the exporter runs in the service manager and cannot access the registry directly.
+ */
+export const settingsPlugin: JupyterFrontEndPlugin<void> = {
+  id: 'jupyterlite-pdf-exporter:settings',
+  description:
+    'Loads the PDF export settings and shares them with the exporter',
+  autoStart: true,
+  requires: [ISettingRegistry],
+  activate: (
+    _app: JupyterFrontEnd,
+    settingRegistry: ISettingRegistry
+  ): void => {
+    const load = (settings: ISettingRegistry.ISettings): void => {
+      pdfExportSettings.update(
+        settings.composite as unknown as Partial<IPdfExportSettings>
+      );
+    };
+
+    settingRegistry
+      .load(PLUGIN_ID)
+      .then(settings => {
+        load(settings);
+        settings.changed.connect(load);
+      })
+      .catch(reason => {
+        console.error(
+          `Failed to load settings for ${PLUGIN_ID}: ${reason}. ` +
+            'Falling back to the default PDF export settings.'
+        );
+      });
+  }
+};

--- a/src/settings-plugin.ts
+++ b/src/settings-plugin.ts
@@ -44,7 +44,8 @@ export const settingsPlugin: JupyterFrontEndPlugin<void> = {
         settings.changed.connect(load);
       })
       .catch(reason => {
-        const message = reason instanceof Error ? reason.message : String(reason);
+        const message =
+          reason instanceof Error ? reason.message : String(reason);
         console.error(
           `Failed to load settings for ${PLUGIN_ID}: ${message}. ` +
             'Falling back to the default PDF export settings.'

--- a/src/settings-plugin.ts
+++ b/src/settings-plugin.ts
@@ -44,8 +44,9 @@ export const settingsPlugin: JupyterFrontEndPlugin<void> = {
         settings.changed.connect(load);
       })
       .catch(reason => {
+        const message = reason instanceof Error ? reason.message : String(reason);
         console.error(
-          `Failed to load settings for ${PLUGIN_ID}: ${reason}. ` +
+          `Failed to load settings for ${PLUGIN_ID}: ${message}. ` +
             'Falling back to the default PDF export settings.'
         );
       });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -85,7 +85,7 @@ export interface IPandocConfig {
 
 /**
  * Translate the user settings into Pandoc options and Typst template variables.
- * TODO: add tests.
+ *
  * This is a pure function so it can be unit tested without the browser. The
  * general rule is to omit any unset or empty value so that Pandoc keeps its
  * default output. The only special case I noticed is page numbering, which

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -105,7 +105,8 @@ export function buildPandocConfig(settings: IPdfExportSettings): IPandocConfig {
     variables.mainfont = settings.mainFont;
   }
   if (settings.linkColor) {
-    variables.linkcolor = settings.linkColor;
+    // Strip leading "#" from colour value
+    variables.linkcolor = settings.linkColor.trim().replace(/^#/, '');
   }
   if (settings.lineSpacing && settings.lineSpacing !== 1) {
     variables.linestretch = settings.lineSpacing;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -104,9 +104,10 @@ export function buildPandocConfig(settings: IPdfExportSettings): IPandocConfig {
   if (settings.mainFont) {
     variables.mainfont = settings.mainFont;
   }
-  if (settings.linkColor) {
+  const linkColor = settings.linkColor.trim();
+  if (linkColor) {
     // Strip leading "#" from colour value
-    variables.linkcolor = settings.linkColor.trim().replace(/^#/, '');
+    variables.linkcolor = linkColor.replace(/^#/, '');
   }
   if (settings.lineSpacing && settings.lineSpacing !== 1) {
     variables.linestretch = settings.lineSpacing;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,186 @@
+// Copyright (c) Agriya Khetarpal
+// SPDX-License-Identifier: BSD-3-Clause
+
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
+/**
+ * The plugin ID whose schema (see schema/plugin.json) holds the PDF export
+ * settings. It matches the ID of the exporter plugin in index.ts.
+ */
+const PLUGIN_ID = 'jupyterlite-pdf-exporter:plugin';
+
+/**
+ * The margins around the page, one length per side (such as "2cm").
+ */
+export interface IPdfMargin {
+  top: string;
+  bottom: string;
+  left: string;
+  right: string;
+}
+
+/**
+ * The user-facing PDF export settings, based on schema/plugin.json.
+ */
+export interface IPdfExportSettings {
+  pageSize: string;
+  fontSize: string;
+  margin: IPdfMargin;
+  mainFont: string;
+  pageNumbers: boolean;
+  tableOfContents: boolean;
+  numberSections: boolean;
+  lineSpacing: number;
+  linkColor: string;
+}
+
+/**
+ * Defaults that match the `default` values in schema/plugin.json. These are
+ * used until the settings registry loads, and as fallbacks for missing keys.
+ */
+const DEFAULT_SETTINGS: IPdfExportSettings = {
+  pageSize: 'a4',
+  fontSize: '10pt',
+  margin: {
+    top: '2.5cm',
+    bottom: '2.5cm',
+    left: '2cm',
+    right: '2cm'
+  },
+  mainFont: 'Libertinus Serif',
+  pageNumbers: true,
+  tableOfContents: false,
+  numberSections: false,
+  lineSpacing: 1,
+  linkColor: ''
+};
+
+/**
+ * A singleton holding the current PDF export settings. It is updated
+ * by the settings frontend plugin and read by the PdfExporter.
+ */
+class PdfExportSettings {
+  get current(): IPdfExportSettings {
+    return this._current;
+  }
+
+  /**
+   * Merge a raw settings object (from `ISettingRegistry`) over the defaults.
+   * Missing or undefined keys keep their default value.
+   */
+  update(raw: Partial<IPdfExportSettings> | null | undefined): void {
+    const r = raw ?? {};
+    this._current = {
+      ...DEFAULT_SETTINGS,
+      ...r,
+      margin: { ...DEFAULT_SETTINGS.margin, ...(r.margin ?? {}) }
+    };
+  }
+
+  private _current: IPdfExportSettings = DEFAULT_SETTINGS;
+}
+
+export const pdfExportSettings = new PdfExportSettings();
+
+/**
+ * These are the pieces of a Pandoc `convert()` call derived from the settings:
+ * top-level options and the template `variables` map.
+ */
+export interface IPandocConfig {
+  options: Record<string, unknown>;
+  variables: Record<string, unknown>;
+}
+
+/**
+ * Translate the user settings into Pandoc options and Typst template variables.
+ * TODO: add tests.
+ * This is a pure function so it can be unit tested without the browser. The
+ * general rule is to omit any unset or empty value so that Pandoc keeps its
+ * default output. The only special case I noticed is page numbering, which
+ * Pandoc turns on by default. We pass "1" to keep it on and "" to turn it off.
+ */
+export function buildPandocConfig(settings: IPdfExportSettings): IPandocConfig {
+  const options: Record<string, unknown> = {};
+  const variables: Record<string, unknown> = {};
+
+  if (settings.pageSize) {
+    variables.papersize = settings.pageSize;
+  }
+  if (settings.fontSize) {
+    variables.fontsize = settings.fontSize;
+  }
+  if (settings.mainFont) {
+    variables.mainfont = settings.mainFont;
+  }
+  if (settings.linkColor) {
+    variables.linkcolor = settings.linkColor;
+  }
+  if (settings.lineSpacing && settings.lineSpacing !== 1) {
+    variables.linestretch = settings.lineSpacing;
+  }
+
+  // Only include margin sides that are set, and only add the map if non-empty
+  const margin: Record<string, string> = {};
+  for (const side of ['top', 'bottom', 'left', 'right'] as const) {
+    const value = settings.margin?.[side];
+    if (value) {
+      margin[side] = value;
+    }
+  }
+  if (Object.keys(margin).length > 0) {
+    variables.margin = margin;
+  }
+
+  // Pandoc numbers pages by default
+  variables['page-numbering'] = settings.pageNumbers ? '1' : '';
+
+  if (settings.tableOfContents) {
+    options['table-of-contents'] = true;
+  }
+  if (settings.numberSections) {
+    options['number-sections'] = true;
+  }
+
+  return { options, variables };
+}
+
+/**
+ * A JupyterFrontEndPlugin that loads the PDF export settings from the settings
+ * registry and keeps the `pdfExportSettings` singleton in sync. We use this as
+ * the exporter runs in the service manager and cannot access the registry directly.
+ */
+export const settingsPlugin: JupyterFrontEndPlugin<void> = {
+  id: 'jupyterlite-pdf-exporter:settings',
+  description:
+    'Loads the PDF export settings and shares them with the exporter',
+  autoStart: true,
+  requires: [ISettingRegistry],
+  activate: (
+    _app: JupyterFrontEnd,
+    settingRegistry: ISettingRegistry
+  ): void => {
+    const load = (settings: ISettingRegistry.ISettings): void => {
+      pdfExportSettings.update(
+        settings.composite as unknown as Partial<IPdfExportSettings>
+      );
+    };
+
+    settingRegistry
+      .load(PLUGIN_ID)
+      .then(settings => {
+        load(settings);
+        settings.changed.connect(load);
+      })
+      .catch(reason => {
+        console.error(
+          `Failed to load customisations/settings for ${PLUGIN_ID}: ${reason}. ` +
+            'Falling back to the default PDF export settings.'
+        );
+      });
+  }
+};

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -44,7 +44,7 @@ const DEFAULT_SETTINGS: IPdfExportSettings = {
   tableOfContents: false,
   numberSections: false,
   lineSpacing: 1,
-  linkColor: ''
+  linkColor: '#0000ee'
 };
 
 /**

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,19 +1,6 @@
 // Copyright (c) Agriya Khetarpal
 // SPDX-License-Identifier: BSD-3-Clause
 
-import {
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin
-} from '@jupyterlab/application';
-
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
-
-/**
- * The plugin ID whose schema (see schema/plugin.json) holds the PDF export
- * settings. It matches the ID of the exporter plugin in index.ts.
- */
-const PLUGIN_ID = 'jupyterlite-pdf-exporter:plugin';
-
 /**
  * The margins around the page, one length per side (such as "2cm").
  */
@@ -148,39 +135,3 @@ export function buildPandocConfig(settings: IPdfExportSettings): IPandocConfig {
 
   return { options, variables };
 }
-
-/**
- * A JupyterFrontEndPlugin that loads the PDF export settings from the settings
- * registry and keeps the `pdfExportSettings` singleton in sync. We use this as
- * the exporter runs in the service manager and cannot access the registry directly.
- */
-export const settingsPlugin: JupyterFrontEndPlugin<void> = {
-  id: 'jupyterlite-pdf-exporter:settings',
-  description:
-    'Loads the PDF export settings and shares them with the exporter',
-  autoStart: true,
-  requires: [ISettingRegistry],
-  activate: (
-    _app: JupyterFrontEnd,
-    settingRegistry: ISettingRegistry
-  ): void => {
-    const load = (settings: ISettingRegistry.ISettings): void => {
-      pdfExportSettings.update(
-        settings.composite as unknown as Partial<IPdfExportSettings>
-      );
-    };
-
-    settingRegistry
-      .load(PLUGIN_ID)
-      .then(settings => {
-        load(settings);
-        settings.changed.connect(load);
-      })
-      .catch(reason => {
-        console.error(
-          `Failed to load customisations/settings for ${PLUGIN_ID}: ${reason}. ` +
-            'Falling back to the default PDF export settings.'
-        );
-      });
-  }
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,20 +2078,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/application@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/application@npm:4.5.6"
+"@jupyterlab/application@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/application@npm:4.5.8"
   dependencies:
     "@fortawesome/fontawesome-free": ^5.12.0
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/docregistry": ^4.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/statedb": ^4.5.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/docregistry": ^4.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/statedb": ^4.5.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/application": ^2.4.8
     "@lumino/commands": ^2.3.3
@@ -2102,23 +2102,23 @@ __metadata:
     "@lumino/properties": ^2.0.4
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
-  checksum: 69b3c188d6d1ab6df1ec97575ba93bdf20512cb92f148654552aaed6334a5d619e1f8212fc9b367e206986e3de00c1c1c502af9bb1e9c74aef8783fd90cff3dc
+  checksum: 5e66f58fb14185470eda0dfab88a7c5599c1a0f678664e1c5d17805d911f4f2a26e68bdbd437867055c01e9ceb4b1a26c227bd12156e7c6a20facd12675f876c
   languageName: node
   linkType: hard
 
-"@jupyterlab/apputils@npm:^4.6.6":
-  version: 4.6.6
-  resolution: "@jupyterlab/apputils@npm:4.6.6"
+"@jupyterlab/apputils@npm:^4.6.8":
+  version: 4.6.8
+  resolution: "@jupyterlab/apputils@npm:4.6.8"
   dependencies:
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/settingregistry": ^4.5.6
-    "@jupyterlab/statedb": ^4.5.6
-    "@jupyterlab/statusbar": ^4.5.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/settingregistry": ^4.5.8
+    "@jupyterlab/statedb": ^4.5.8
+    "@jupyterlab/statusbar": ^4.5.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/commands": ^2.3.3
     "@lumino/coreutils": ^2.2.2
@@ -2131,27 +2131,27 @@ __metadata:
     "@types/react": ^18.0.26
     react: ^18.2.0
     sanitize-html: ~2.12.1
-  checksum: 5c72ae37b8f4671786b7ca94a019fc8bdf743afe76f33bc471767fa54b861bda564b50dd2b2eae5b57ee862b169e0155f190f76e4bdcc7d33a1cd0ee2842bed3
+  checksum: b955e8c03faae1bd03b00a9d4bc7f4261b91dd6581b88478f1dcebaf2ec42567d5e6e55811b08663e9f8b133e5ed36f86f6715215aebd832a073e609a36c6867
   languageName: node
   linkType: hard
 
-"@jupyterlab/attachments@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/attachments@npm:4.5.6"
+"@jupyterlab/attachments@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/attachments@npm:4.5.8"
   dependencies:
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
     "@lumino/disposable": ^2.1.5
     "@lumino/signaling": ^2.1.5
-  checksum: 80318fb705467a0e9547c3918f046d701e0be493d1e39e35ce71bee365f924cb85e2e4ddf0c8087a0e42222efed7abdb578a5e5e17e46409d6ebb71df280b514
+  checksum: 4827a035893246c5949b301d05726cf14db032cf9412be0a7f63ac4b1b62116fa8ea097c3309f55b38aabb7a63752e71357ecb13601d9e1a933124575fb823fe
   languageName: node
   linkType: hard
 
-"@jupyterlab/builder@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/builder@npm:4.5.6"
+"@jupyterlab/builder@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/builder@npm:4.5.8"
   dependencies:
     "@lumino/algorithm": ^2.0.4
     "@lumino/application": ^2.4.8
@@ -2171,7 +2171,7 @@ __metadata:
     duplicate-package-checker-webpack-plugin: ^3.0.0
     fs-extra: ^10.1.0
     glob: ~7.1.6
-    license-webpack-plugin: ^2.3.14
+    license-webpack-plugin: ^4.0.2
     mini-css-extract-plugin: ^2.7.0
     mini-svg-data-uri: ^1.4.4
     path-browserify: ^1.0.0
@@ -2183,35 +2183,36 @@ __metadata:
     webpack: ^5.76.1
     webpack-cli: ^5.0.1
     webpack-merge: ^5.8.0
+    webpack-sources: ^3.4.1
     worker-loader: ^3.0.2
   bin:
     build-labextension: lib/build-labextension.js
-  checksum: ecb43e0e748cb53d1a6908a3c6b094f6214d60c4fb17503d6d6b2aeb09424d9a95eef74b61c1dbec10f7c6e42254c66513088d0c4713fbceb2712084a6cd4ab3
+  checksum: 7fda678ad4363731015ca0875f1f67d5988b1eab01db07ea7f47c32a7edfdb5058d1aa67296d77f313688cd257dc229a2992a35ecf4e942d52df35adcbc040e9
   languageName: node
   linkType: hard
 
-"@jupyterlab/cells@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/cells@npm:4.5.6"
+"@jupyterlab/cells@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/cells@npm:4.5.8"
   dependencies:
     "@codemirror/state": ^6.5.4
     "@codemirror/view": ^6.39.14
     "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/attachments": ^4.5.6
-    "@jupyterlab/codeeditor": ^4.5.6
-    "@jupyterlab/codemirror": ^4.5.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/documentsearch": ^4.5.6
-    "@jupyterlab/filebrowser": ^4.5.6
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/outputarea": ^4.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/toc": ^6.5.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/attachments": ^4.5.8
+    "@jupyterlab/codeeditor": ^4.5.8
+    "@jupyterlab/codemirror": ^4.5.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/documentsearch": ^4.5.8
+    "@jupyterlab/filebrowser": ^4.5.8
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/outputarea": ^4.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/toc": ^6.5.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/domutils": ^2.0.4
@@ -2222,23 +2223,23 @@ __metadata:
     "@lumino/virtualdom": ^2.0.4
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
-  checksum: 587b0e4e897663da642dcf63c1d9d7f5d7eb69dc47427d120c76bfd6eb80c4c1d2bbf8bf7f67484170f253a0c099613b2c349b2e962c50233cf651b463f536cd
+  checksum: 5513617bfe52f28a2af18a968230d34c46220f861f51f84950e3ebb4011bc0efaf47fd35d28c30c46df62f98a73968acbf7efd1f95338e42fa7267f2945f8d4a
   languageName: node
   linkType: hard
 
-"@jupyterlab/codeeditor@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/codeeditor@npm:4.5.6"
+"@jupyterlab/codeeditor@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/codeeditor@npm:4.5.8"
   dependencies:
     "@codemirror/state": ^6.5.4
     "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/statusbar": ^4.5.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/statusbar": ^4.5.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
     "@lumino/dragdrop": ^2.1.8
@@ -2246,13 +2247,13 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
-  checksum: 298cab335372ba900dcf1f811f31272f2fb214b42411eca44b39c66c1910b865a223015642b3f8ddc0a24e1a5eba7b424f771ded735f74e602d21491ad3c945f
+  checksum: e1d853201e4183d386deddf9d8b7ad8963631e48f9470aea7d986ce5294375caec27d9a6e9b0d5fc3115aa5a47f5c0f9f9dbc946c758a54b6d5348cd6a83794c
   languageName: node
   linkType: hard
 
-"@jupyterlab/codemirror@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/codemirror@npm:4.5.6"
+"@jupyterlab/codemirror@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/codemirror@npm:4.5.8"
   dependencies:
     "@codemirror/autocomplete": ^6.20.0
     "@codemirror/commands": ^6.10.2
@@ -2275,11 +2276,11 @@ __metadata:
     "@codemirror/state": ^6.5.4
     "@codemirror/view": ^6.39.14
     "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/codeeditor": ^4.5.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/documentsearch": ^4.5.6
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/codeeditor": ^4.5.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/documentsearch": ^4.5.8
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/translation": ^4.5.8
     "@lezer/common": ^1.2.1
     "@lezer/generator": ^1.7.0
     "@lezer/highlight": ^1.2.0
@@ -2288,13 +2289,13 @@ __metadata:
     "@lumino/disposable": ^2.1.5
     "@lumino/signaling": ^2.1.5
     yjs: ^13.5.40
-  checksum: 41ac99b7fc675875c7eece4b24f779cd7e26b525cb9646c7ffbeeb70c0c5d6e1221175d12dc62f3b0dcbdb9ee5cef9dbc60b4227f2a950c62502249e4dca7f40
+  checksum: 5c0c3c146fd6265c8fb61043e633c0c00a9ef506c7faee7075ffdf0c85e0088d78f4f29a4b6a81bd910c2e56184c661dd6c9d042fa96209b902fe969d5e58951
   languageName: node
   linkType: hard
 
-"@jupyterlab/coreutils@npm:^6.5.6, @jupyterlab/coreutils@npm:~6.5.6":
-  version: 6.5.6
-  resolution: "@jupyterlab/coreutils@npm:6.5.6"
+"@jupyterlab/coreutils@npm:^6.5.8, @jupyterlab/coreutils@npm:~6.5.7":
+  version: 6.5.8
+  resolution: "@jupyterlab/coreutils@npm:6.5.8"
   dependencies:
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2302,23 +2303,23 @@ __metadata:
     minimist: ~1.2.0
     path-browserify: ^1.0.0
     url-parse: ~1.5.4
-  checksum: e693f47d86dcff9762340d8a7df504b9b258a03785243b8aac8606321216efac9c965bbf4197abbcb1f175dade44d0f53f0a9ff70f14a16e5243fae3a5ef16cf
+  checksum: 31d404df083670cc9b2da339962905cb471bae9c621491673d84831ebc951e319d97ccb1dfab1059f3a7fddeb156eace4903c0bc428372760af08d6f28f320b8
   languageName: node
   linkType: hard
 
-"@jupyterlab/docmanager@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/docmanager@npm:4.5.6"
+"@jupyterlab/docmanager@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/docmanager@npm:4.5.8"
   dependencies:
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/docregistry": ^4.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/statedb": ^4.5.6
-    "@jupyterlab/statusbar": ^4.5.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/docregistry": ^4.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/statedb": ^4.5.8
+    "@jupyterlab/statusbar": ^4.5.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2328,24 +2329,24 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
-  checksum: 6f0458b2bbebe3982d9d0bbea7775ac135e7e121772c8a40633303bc8ce98d5100895db044074b968f71a180ea327cad40193778057ed57f00c264c14d63b1ed
+  checksum: f51bc6b0eddda01148c7e6c841622d03ff3f2276223c941e86765295aa49548ef67531d8a666017bdd75315feb4db264ee8d482f3f2670984793f7f1de3a72ce
   languageName: node
   linkType: hard
 
-"@jupyterlab/docregistry@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/docregistry@npm:4.5.6"
+"@jupyterlab/docregistry@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/docregistry@npm:4.5.8"
   dependencies:
     "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/codeeditor": ^4.5.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/codeeditor": ^4.5.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2354,17 +2355,17 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
-  checksum: e57126380d3abca32165c659fc3dd63c4642abc2dfe35017c38fd4ca91ae9cfcb95427c98fd47aa0f546c8030eb1af42be60c2a40bc03f4411fa9f92b77a4fe3
+  checksum: 3e4b2520ee99a1abbb4695854db5e47ce6498d43db2cb28accc0f380314e0d27913c71e9ed5963d973bd90292f9a6c79ab2c02ef11cfb4fa4d4e426b0811d3d0
   languageName: node
   linkType: hard
 
-"@jupyterlab/documentsearch@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/documentsearch@npm:4.5.6"
+"@jupyterlab/documentsearch@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/documentsearch@npm:4.5.8"
   dependencies:
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/commands": ^2.3.3
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2373,23 +2374,23 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
-  checksum: d76bebc8d2ee7b76e476b145aff773e637e8c11d5d40bf9035b5dd8bd00fc712a3347327ff2eff0387095e12777eb53a6416502e2c17517027a42c8e0592261a
+  checksum: 98fa506f23075668dc7e2d4647630c0ec990ca3690329ae2c9cff05798c40451f6466762c0cf8a53701a55b75fdbd88729243c996d6a500d256e8f49df99bade
   languageName: node
   linkType: hard
 
-"@jupyterlab/filebrowser@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/filebrowser@npm:4.5.6"
+"@jupyterlab/filebrowser@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/filebrowser@npm:4.5.8"
   dependencies:
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/docmanager": ^4.5.6
-    "@jupyterlab/docregistry": ^4.5.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/statedb": ^4.5.6
-    "@jupyterlab/statusbar": ^4.5.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/docmanager": ^4.5.8
+    "@jupyterlab/docregistry": ^4.5.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/statedb": ^4.5.8
+    "@jupyterlab/statusbar": ^4.5.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2402,21 +2403,21 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     jest-environment-jsdom: ^29.3.0
     react: ^18.2.0
-  checksum: d8fb64ccfa2ffb19d16ce041efdca8877838f6f5738f99411c67cc235465fbfd82bdc1f156bba0a93266d4c581ceb5e1212e6ec1413799522acad19231a474e7
+  checksum: e3dc8060ec877490e775823fd2b8f57602e2e10a61aef9a2385843852bf035f844315b1b63819863ee9953224726d33b74677edc3a9e2b58cf23b50e8c0782aa
   languageName: node
   linkType: hard
 
-"@jupyterlab/lsp@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/lsp@npm:4.5.6"
+"@jupyterlab/lsp@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/lsp@npm:4.5.8"
   dependencies:
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/codeeditor": ^4.5.6
-    "@jupyterlab/codemirror": ^4.5.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/docregistry": ^4.5.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/codeeditor": ^4.5.8
+    "@jupyterlab/codemirror": ^4.5.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/docregistry": ^4.5.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/translation": ^4.5.8
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
     "@lumino/signaling": ^2.1.5
@@ -2425,43 +2426,43 @@ __metadata:
     vscode-jsonrpc: ^6.0.0
     vscode-languageserver-protocol: ^3.17.0
     vscode-ws-jsonrpc: ~1.0.2
-  checksum: efaeaa3b8a740b40ad8fc5b99ab4777bd6287397844c84804ffa1000e8e349fd726b36259abf3ec13a062d86e6b4a1070bf998314149676176341f03204f5537
+  checksum: 003fd04cf621436a0a7bc41d2ca56572b33046dcf24fcc562d9e7a41d8df3dedaa682c5ee99b6ea4d85cfe8766c2698034ef50ae520b17970afd98bebaa689f4
   languageName: node
   linkType: hard
 
-"@jupyterlab/markedparser-extension@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/markedparser-extension@npm:4.5.6"
+"@jupyterlab/markedparser-extension@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/markedparser-extension@npm:4.5.8"
   dependencies:
-    "@jupyterlab/application": ^4.5.6
-    "@jupyterlab/codemirror": ^4.5.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/mermaid": ^4.5.6
-    "@jupyterlab/rendermime": ^4.5.6
+    "@jupyterlab/application": ^4.5.8
+    "@jupyterlab/codemirror": ^4.5.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/mermaid": ^4.5.8
+    "@jupyterlab/rendermime": ^4.5.8
     "@lumino/coreutils": ^2.2.2
     marked: ^17.0.2
     marked-gfm-heading-id: ^4.1.3
     marked-mangle: ^1.1.12
-  checksum: 9f3b610497a18e34608f49f3dffade691c2b09c0ffbf44ab865dfe1f218571e4c99e9f518b811a97782c753986651525aa8cdfbfb40c4a286880736cffb7f74b
+  checksum: f9f06a3f02ceadb4d94a37fd1271b10841318afb201354eecf91faa99dc155b5362d9c9a3db0158122284bf8ff0505498c183d32fed9c5bc8a16f153889d6601
   languageName: node
   linkType: hard
 
-"@jupyterlab/mermaid@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/mermaid@npm:4.5.6"
+"@jupyterlab/mermaid@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/mermaid@npm:4.5.8"
   dependencies:
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
     "@lumino/coreutils": ^2.2.2
     "@lumino/widgets": ^2.7.5
     "@mermaid-js/layout-elk": ^0.2.0
     mermaid: ^11.12.3
-  checksum: 0ffef133463544bbf50c729c507a220e8386aab2727b27803ba8c315e308c1c25273dae5e5bc2f295802b9bbc46bd8fd3a0ee1a9d9d63a756be72da4c236c9e0
+  checksum: 95db981f2c397fd35919c70db72a751d7f969d1db14cd1ba9c1019c1b0fcd72e44029e1cf9ed27f038b1062a328f0e5a90cae67bd3374bc8378850b0b516fad5
   languageName: node
   linkType: hard
 
-"@jupyterlab/nbformat@npm:^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0, @jupyterlab/nbformat@npm:^4.5.6, @jupyterlab/nbformat@npm:~4.5.6":
+"@jupyterlab/nbformat@npm:^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0":
   version: 4.5.6
   resolution: "@jupyterlab/nbformat@npm:4.5.6"
   dependencies:
@@ -2470,29 +2471,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/notebook@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/notebook@npm:4.5.6"
+"@jupyterlab/nbformat@npm:^4.5.8, @jupyterlab/nbformat@npm:~4.5.7":
+  version: 4.5.8
+  resolution: "@jupyterlab/nbformat@npm:4.5.8"
+  dependencies:
+    "@lumino/coreutils": ^2.2.2
+  checksum: bc827cb51fdc511446e8e51435efbca8d27dd55a6d13f04dc33b9ed837065b85c12470caf80aec03db216860bff9414d4b20c000d231a46ffc3538e6b136c3bc
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/notebook@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/notebook@npm:4.5.8"
   dependencies:
     "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/cells": ^4.5.6
-    "@jupyterlab/codeeditor": ^4.5.6
-    "@jupyterlab/codemirror": ^4.5.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/docregistry": ^4.5.6
-    "@jupyterlab/documentsearch": ^4.5.6
-    "@jupyterlab/lsp": ^4.5.6
-    "@jupyterlab/markedparser-extension": ^4.5.6
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/settingregistry": ^4.5.6
-    "@jupyterlab/statusbar": ^4.5.6
-    "@jupyterlab/toc": ^6.5.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/cells": ^4.5.8
+    "@jupyterlab/codeeditor": ^4.5.8
+    "@jupyterlab/codemirror": ^4.5.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/docregistry": ^4.5.8
+    "@jupyterlab/documentsearch": ^4.5.8
+    "@jupyterlab/lsp": ^4.5.8
+    "@jupyterlab/markedparser-extension": ^4.5.8
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/settingregistry": ^4.5.8
+    "@jupyterlab/statusbar": ^4.5.8
+    "@jupyterlab/toc": ^6.5.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2505,34 +2515,34 @@ __metadata:
     "@lumino/virtualdom": ^2.0.4
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
-  checksum: 7e3fa18f0c9a99ec6dc5ba629fbd53f17539a1eb917b54f3d044cecf76e89bafa74fc854ad099bb1a9f364844990990714f016fa6a176dd2ccf8a4bb84bba1f2
+  checksum: d27bfaa765073da90036a4a410e6eba863793e1a81aebd1483eeb2555e796aef70e4162d0d4614980ef60d5091ca17f74dcbedb7911b9de055df3e3347905751
   languageName: node
   linkType: hard
 
-"@jupyterlab/observables@npm:^5.5.6, @jupyterlab/observables@npm:~5.5.6":
-  version: 5.5.6
-  resolution: "@jupyterlab/observables@npm:5.5.6"
+"@jupyterlab/observables@npm:^5.5.8, @jupyterlab/observables@npm:~5.5.7":
+  version: 5.5.8
+  resolution: "@jupyterlab/observables@npm:5.5.8"
   dependencies:
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
     "@lumino/messaging": ^2.0.4
     "@lumino/signaling": ^2.1.5
-  checksum: 1c1e04644929f2f8535126244c71bc916e1759b256d6442cfeef2fb68ebeaa872aa4cabc7dadce1c14ab419a742be9ef30b6e940b09d559705d47858a55b4174
+  checksum: 3a71f84a37bc6e245274b3355c30a06b52126c112efbd98cab1d7f4d0154b02e24e35e1c524a4aba80fb9633dc47a169946998f1035668dedcc7366992cde076
   languageName: node
   linkType: hard
 
-"@jupyterlab/outputarea@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/outputarea@npm:4.5.6"
+"@jupyterlab/outputarea@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/outputarea@npm:4.5.8"
   dependencies:
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/translation": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2540,65 +2550,65 @@ __metadata:
     "@lumino/properties": ^2.0.4
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
-  checksum: c0a42f0b12cc5b4c0ef20650d1f39a03dc0736db278ae2b1155927708e6783344603c1c221c7abf436f559551039a011f2ef39479992bd81e90622618df105e3
+  checksum: f960ce29ddb148e693ddd9927b909946b4c76717359c93c0153486e3cedac4aff76e59d63acafed77faba63d74d0a2286bf45e30f690982e8742b840c4a28e23
   languageName: node
   linkType: hard
 
-"@jupyterlab/rendermime-interfaces@npm:^3.13.6":
-  version: 3.13.6
-  resolution: "@jupyterlab/rendermime-interfaces@npm:3.13.6"
+"@jupyterlab/rendermime-interfaces@npm:^3.13.8":
+  version: 3.13.8
+  resolution: "@jupyterlab/rendermime-interfaces@npm:3.13.8"
   dependencies:
     "@lumino/coreutils": ^1.11.0 || ^2.2.2
     "@lumino/widgets": ^1.37.2 || ^2.7.5
-  checksum: 23bbf8f18712d6f14444ef20ed851fa8d787f4cdfaf4e43348365a3d6042ff1fe43e738b99a0e6a921d8205f7b97cc8d4016eb0863950266e105699fcd13a8d6
+  checksum: 030beb9632e2e6b0d32bb1e11b526600cd42d92770a66e49d884d5fe6fdc585ca3f84fc96c86e276ca212e2f0d31a0a00ffd6bfce74c6dbe582fca81ddad2e8f
   languageName: node
   linkType: hard
 
-"@jupyterlab/rendermime@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/rendermime@npm:4.5.6"
+"@jupyterlab/rendermime@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/rendermime@npm:4.5.8"
   dependencies:
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/translation": ^4.5.8
     "@lumino/coreutils": ^2.2.2
     "@lumino/messaging": ^2.0.4
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     lodash.escape: ^4.0.1
-  checksum: 8c944ea0358cdabc5f8c7a4b3df1f8da48898dd0c3f3da0afe97bb36155b3172ce8061c87cdf98f71970893b05199d7e420eefdd85c7c89fd355639a493370c0
+  checksum: 1187c757b1ce477fb6524e990d551dd85e72cb8b78c18cee0ec27c49059ceae561ca713298cb9216101f76ac0789d605d6736362f3c16016183e19854f31dd33
   languageName: node
   linkType: hard
 
-"@jupyterlab/services@npm:^7.5.6, @jupyterlab/services@npm:~7.5.6":
-  version: 7.5.6
-  resolution: "@jupyterlab/services@npm:7.5.6"
+"@jupyterlab/services@npm:^7.5.8, @jupyterlab/services@npm:~7.5.7":
+  version: 7.5.8
+  resolution: "@jupyterlab/services@npm:7.5.8"
   dependencies:
     "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/settingregistry": ^4.5.6
-    "@jupyterlab/statedb": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/settingregistry": ^4.5.8
+    "@jupyterlab/statedb": ^4.5.8
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
     "@lumino/polling": ^2.1.5
     "@lumino/properties": ^2.0.4
     "@lumino/signaling": ^2.1.5
     ws: ^8.11.0
-  checksum: c5b0d9ba7f2ccc245eb7bbf6f32c174116ff70f7d173168b66649b6d35cbca118e2e1be6fa7f305979eac3c8478dc228990b1c5537aec96b51cd637b2ab792a3
+  checksum: 41ba45fda561c0011c784957aa64c96e3a83efe3a68d90586ca3578a919219eae0fb49c49cdf029cda71eaaeddce227c506cc3d06aad287883eb698ff550559a
   languageName: node
   linkType: hard
 
-"@jupyterlab/settingregistry@npm:^4.5.6, @jupyterlab/settingregistry@npm:~4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/settingregistry@npm:4.5.6"
+"@jupyterlab/settingregistry@npm:^4.5.8, @jupyterlab/settingregistry@npm:~4.5.7":
+  version: 4.5.8
+  resolution: "@jupyterlab/settingregistry@npm:4.5.8"
   dependencies:
-    "@jupyterlab/nbformat": ^4.5.6
-    "@jupyterlab/statedb": ^4.5.6
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/statedb": ^4.5.8
     "@lumino/commands": ^2.3.3
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2608,28 +2618,28 @@ __metadata:
     json5: ^2.2.3
   peerDependencies:
     react: ">=16"
-  checksum: fd8490e0a2e7a8359fc6c87e1988bda6ce168be202fba3888b77a9bbd4b0967a2486d39c73464f2295a17615cc715ab48733e6fa4d52b4565bb003e3d586c99b
+  checksum: 900f0160f75220f7e51d91dada6c3d69bd0cb28f9c2361935e5f3425e7076e98c7babd63702683635cfd977a7129e6068b949e11389bf2d9eacea8afb9e24ff5
   languageName: node
   linkType: hard
 
-"@jupyterlab/statedb@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/statedb@npm:4.5.6"
+"@jupyterlab/statedb@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/statedb@npm:4.5.8"
   dependencies:
     "@lumino/commands": ^2.3.3
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
     "@lumino/properties": ^2.0.4
     "@lumino/signaling": ^2.1.5
-  checksum: 5a9a237ed1cd215ddb672bc080da5966320716b7ea6a018eeca2c5cc3689b0b9709843e1ef2452657976b751ce00cf64c82375f3dc796d844f94dcf856c50884
+  checksum: 2b67cdd318f5d6ef53eee5c8219997c33874e76aca960e434207e7211e303dab0712baea60320b618d369f178c0f46801ad804da918c04d68bb45435571f8735
   languageName: node
   linkType: hard
 
-"@jupyterlab/statusbar@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/statusbar@npm:4.5.6"
+"@jupyterlab/statusbar@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/statusbar@npm:4.5.8"
   dependencies:
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2637,17 +2647,17 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
-  checksum: 80a5bc008827f32f8fb99e913262eaeba27e5ec92ca8e194d856e071efa1f62189a369b2c9276808377c7740ea27bbd5f8430b51e3c7a9ea1d8017f166594425
+  checksum: 24b8a4a494131f9604bf1f6287a385092cf2d38963181a8969eee1446c2e8d2807e9d1d7b4dcdcc46ae15625d5d0125e7afc43a4089279a7c3589c32f21fb0e9
   languageName: node
   linkType: hard
 
-"@jupyterlab/testing@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/testing@npm:4.5.6"
+"@jupyterlab/testing@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/testing@npm:4.5.8"
   dependencies:
     "@babel/core": ^7.10.2
     "@babel/preset-env": ^7.10.2
-    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/coreutils": ^6.5.8
     "@lumino/coreutils": ^2.2.2
     "@lumino/signaling": ^2.1.5
     deepmerge: ^4.2.2
@@ -2660,69 +2670,69 @@ __metadata:
     ts-jest: ^29.1.0
   peerDependencies:
     typescript: ">=4.3"
-  checksum: b630c7da1e5d7ab6fb567f48148f06622a622a4125a365e9ea9ffb0cbf8530b6567ee8de234d4152bdce06bd1f8e80d6c6d5626847de370013683219c41df8d0
+  checksum: 978ef04edcb2dee620815dce32db91489292e49d5e9eaf2d69897c224b94dbfc779e52c4fd1892f947fe60cb8ada2f66c86025b33a56cbd0b04a5a5b80524c50
   languageName: node
   linkType: hard
 
-"@jupyterlab/testutils@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/testutils@npm:4.5.6"
+"@jupyterlab/testutils@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/testutils@npm:4.5.8"
   dependencies:
-    "@jupyterlab/application": ^4.5.6
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/notebook": ^4.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/testing": ^4.5.6
-  checksum: 940a4c8f938bb166857bbf6720a322a6b53bfcaa4e27da6e7b40f57302f33ce8616940d401194c79fb560d247ad8ac9c8521b1147d40e802560752042df7ef25
+    "@jupyterlab/application": ^4.5.8
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/notebook": ^4.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/testing": ^4.5.8
+  checksum: 30659ae16f7cae31f5467fe509a45c562b2af505b5511d166751a0ae30299d4909871b5b4ac9efe1acbca29e741278c5fd28677d032866995cd2597aa96e005f
   languageName: node
   linkType: hard
 
-"@jupyterlab/toc@npm:^6.5.6":
-  version: 6.5.6
-  resolution: "@jupyterlab/toc@npm:6.5.6"
+"@jupyterlab/toc@npm:^6.5.8":
+  version: 6.5.8
+  resolution: "@jupyterlab/toc@npm:6.5.8"
   dependencies:
     "@jupyter/react-components": ^0.16.6
-    "@jupyterlab/apputils": ^4.6.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/docregistry": ^4.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/rendermime": ^4.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
-    "@jupyterlab/translation": ^4.5.6
-    "@jupyterlab/ui-components": ^4.5.6
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/docregistry": ^4.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/rendermime": ^4.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
     "@lumino/messaging": ^2.0.4
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
-  checksum: 17344ecdcea645969f0f2d17a89c8afc7f0e3396b613ef8dc09fc47493e7099dcc3833c1d1b288cef440473f6c0b0cdef3b88a42d5b2c412d4a67a3e49da3f85
+  checksum: 4a4995ac03f0502eaf5a32048b59e683205628b7d08fd297e6697b09c3dd173fc8edc38ac179b3d2cd2daef67a608216d084c55557a8c21f7d7b5b912acda59f
   languageName: node
   linkType: hard
 
-"@jupyterlab/translation@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/translation@npm:4.5.6"
+"@jupyterlab/translation@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/translation@npm:4.5.8"
   dependencies:
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/statedb": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/statedb": ^4.5.8
     "@lumino/coreutils": ^2.2.2
-  checksum: 05db816acc6b908a02c80ff67c2239a54f1b43260b57ffc0038224ec5d082ed6167d27d4e3cccfd871f7408c10e6c36c8ab9fcd419b69e7a9ded4307bf3e16ad
+  checksum: e54960d3fde3d4222863d55c24947139f57822265e72050b149aae05012dda842f20439e23e3ec350d2c1543e760b08082e104baa4f16532468cd064def0fead
   languageName: node
   linkType: hard
 
-"@jupyterlab/ui-components@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@jupyterlab/ui-components@npm:4.5.6"
+"@jupyterlab/ui-components@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/ui-components@npm:4.5.8"
   dependencies:
     "@jupyter/react-components": ^0.16.6
     "@jupyter/web-components": ^0.16.6
-    "@jupyterlab/coreutils": ^6.5.6
-    "@jupyterlab/observables": ^5.5.6
-    "@jupyterlab/rendermime-interfaces": ^3.13.6
-    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.8
+    "@jupyterlab/observables": ^5.5.8
+    "@jupyterlab/rendermime-interfaces": ^3.13.8
+    "@jupyterlab/translation": ^4.5.8
     "@lumino/algorithm": ^2.0.4
     "@lumino/commands": ^2.3.3
     "@lumino/coreutils": ^2.2.2
@@ -2740,32 +2750,32 @@ __metadata:
     typestyle: ^2.0.4
   peerDependencies:
     react: ^18.2.0
-  checksum: 23749d9ba442a49676c95c371c04440b55843d18b121723e170bcb086c4e447d7484745e873cdf47f256e1497304d07370bef875a8c80a5d15bbd5f54c2662a5
+  checksum: 26730193f24bf340cfb67a04916845238da3907f1b8ca6dc61f312ef2875f56c2d2bae757e14a488ec57e5139f46d45b822ba5361bea5dd638f1898e1a4be531
   languageName: node
   linkType: hard
 
-"@jupyterlite/localforage@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "@jupyterlite/localforage@npm:0.7.4"
+"@jupyterlite/localforage@npm:^0.7.6":
+  version: 0.7.6
+  resolution: "@jupyterlite/localforage@npm:0.7.6"
   dependencies:
-    "@jupyterlab/coreutils": ~6.5.6
+    "@jupyterlab/coreutils": ~6.5.7
     "@lumino/coreutils": ^2.2.2
     localforage: ^1.9.0
     localforage-memoryStorageDriver: ^0.9.2
-  checksum: 74a65dda746e19028d391d31e2ae82bc1acdc7ce7ffac6ee22864337fb82ab015933dd8208183cc52481f1e6e1b6358ebe32a0939c645e7c3887d2712e43e679
+  checksum: 64da9d2145d5cabe0bff502f304c6fbc246b6791a89f79747c61633c504c23c0ba6482b27852e96377acec4bb8ef6b5476a61fd7f24e76815db1c64fb3484efb
   languageName: node
   linkType: hard
 
-"@jupyterlite/services@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "@jupyterlite/services@npm:0.7.4"
+"@jupyterlite/services@npm:^0.7.6":
+  version: 0.7.6
+  resolution: "@jupyterlite/services@npm:0.7.6"
   dependencies:
-    "@jupyterlab/coreutils": ~6.5.6
-    "@jupyterlab/nbformat": ~4.5.6
-    "@jupyterlab/observables": ~5.5.6
-    "@jupyterlab/services": ~7.5.6
-    "@jupyterlab/settingregistry": ~4.5.6
-    "@jupyterlite/localforage": ^0.7.4
+    "@jupyterlab/coreutils": ~6.5.7
+    "@jupyterlab/nbformat": ~4.5.7
+    "@jupyterlab/observables": ~5.5.7
+    "@jupyterlab/services": ~7.5.7
+    "@jupyterlab/settingregistry": ~4.5.7
+    "@jupyterlite/localforage": ^0.7.6
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2777,7 +2787,7 @@ __metadata:
     localforage: ^1.9.0
     mime: ^3.0.0
     mock-socket: ^9.3.1
-  checksum: 49d642b72ff1cca23eb6b82cc933de32c59f3cea49c71876c53049e8eb001163e32701562cfbc8620a7e7b24b78bc4b0afbca4a20855f5442cee86df04aaca17
+  checksum: ea2140367e35903db3ae31bdad6995fb70cd8102e71b78e3d755a920c074d99858e89a8b1d7b344df92d69e81edc88b37a02fa340a58532ebbc709c7d11124d4
   languageName: node
   linkType: hard
 
@@ -3753,13 +3763,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/source-list-map@npm:*":
-  version: 0.1.6
-  resolution: "@types/source-list-map@npm:0.1.6"
-  checksum: 9cd294c121f1562062de5d241fe4d10780b1131b01c57434845fe50968e9dcf67ede444591c2b1ad6d3f9b6bc646ac02cc8f51a3577c795f9c64cf4573dcc6b1
-  languageName: node
-  linkType: hard
-
 "@types/stack-utils@npm:^2.0.0, @types/stack-utils@npm:^2.0.3":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
@@ -3778,17 +3781,6 @@ __metadata:
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
-  languageName: node
-  linkType: hard
-
-"@types/webpack-sources@npm:^0.1.5":
-  version: 0.1.12
-  resolution: "@types/webpack-sources@npm:0.1.12"
-  dependencies:
-    "@types/node": "*"
-    "@types/source-list-map": "*"
-    source-map: ^0.6.1
-  checksum: 75342659a9889478969f7bb7360b998aa084ba11ab523c172ded6a807dac43ab2a9e1212078ef8bbf0f33e4fadd2c8a91b75d38184d8030d96a32fe819c9bb57
   languageName: node
   linkType: hard
 
@@ -7666,12 +7658,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jupyterlite-pdf-exporter@workspace:."
   dependencies:
-    "@jupyterlab/application": ^4.5.6
-    "@jupyterlab/builder": ^4.5.6
-    "@jupyterlab/services": ^7.5.6
-    "@jupyterlab/statusbar": ^4.5.6
-    "@jupyterlab/testutils": ^4.5.6
-    "@jupyterlite/services": ^0.7.4
+    "@jupyterlab/application": ^4.5.8
+    "@jupyterlab/builder": ^4.5.8
+    "@jupyterlab/services": ^7.5.8
+    "@jupyterlab/settingregistry": ^4.5.8
+    "@jupyterlab/statusbar": ^4.5.8
+    "@jupyterlab/testutils": ^4.5.8
+    "@jupyterlite/services": ^0.7.6
     "@myriaddreamin/typst-all-in-one.ts": 0.7.0-rc2
     "@types/emscripten": ^1.41.5
     "@types/jest": ^30.0.0
@@ -7790,16 +7783,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"license-webpack-plugin@npm:^2.3.14":
-  version: 2.3.21
-  resolution: "license-webpack-plugin@npm:2.3.21"
+"license-webpack-plugin@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "license-webpack-plugin@npm:4.0.2"
   dependencies:
-    "@types/webpack-sources": ^0.1.5
-    webpack-sources: ^1.2.0
+    webpack-sources: ^3.0.0
   peerDependenciesMeta:
     webpack:
       optional: true
-  checksum: 6208bd2060d200fbffbcc89702c929d50c5a4a3f2158b046cf813b3f7f728bbbe4611b9fea2d67843bb5e7d64ad9122cc368a19ac73f5c4ad41765e6283bdc0c
+    webpack-sources:
+      optional: true
+  checksum: e88ebdb9c8bdfc0926dd7211d7fe2ee8697a44bb00a96bb5e6ca844b6acb7d24dd54eb17ec485e2e0140c3cc86709d1c2bd46e091ab52af076e1e421054c8322
   languageName: node
   linkType: hard
 
@@ -9373,13 +9367,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-list-map@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "source-list-map@npm:2.0.1"
-  checksum: 806efc6f75e7cd31e4815e7a3aaf75a45c704871ea4075cb2eb49882c6fca28998f44fc5ac91adb6de03b2882ee6fb02f951fdc85e6a22b338c32bfe19557938
-  languageName: node
-  linkType: hard
-
 "source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -10209,13 +10196,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^1.2.0":
-  version: 1.4.3
-  resolution: "webpack-sources@npm:1.4.3"
-  dependencies:
-    source-list-map: ^2.0.0
-    source-map: ~0.6.1
-  checksum: 37463dad8d08114930f4bc4882a9602941f07c9f0efa9b6bc78738cd936275b990a596d801ef450d022bb005b109b9f451dd087db2f3c9baf53e8e22cf388f79
+"webpack-sources@npm:^3.0.0, webpack-sources@npm:^3.4.1":
+  version: 3.5.0
+  resolution: "webpack-sources@npm:3.5.0"
+  checksum: 748e288620d0731be0f89efaf9cce752d245e224b4d74361d1150ebe680338946ced1bbcc0a67b887cf0a86e1ed4d6c68770b7b7c46f83975c0bc30eb8c64ff6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:
- Adds extension settings that map to Pandoc template variables, which are passed along when generating the Typst IR.
- Enables setting `ISettingRegistry` to build the plumbing required to map these extension settings (camelCase) to Pandoc configuration
- Adds a `settingsPlugin` (as a frontend plugin) which communicates with the exporter, which is a  `ServiceManagerPlugin`
- Bumps dependencies to the latest JupyterLab|Lite
- Adds related unit tests
- Adds a schema for all the enabled settings 
- Updates the documentation about all available customisations

Closes #8 