### PR TITLE
Add support for JupyterLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@
 [![Try PDF exporter in JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://agriyakhetarp.al/jupyterlite-pdf-exporter/)
 [![PyPI version](https://badge.fury.io/py/jupyterlite-pdf-exporter.svg)](https://pypi.org/project/jupyterlite-pdf-exporter/)
 
-A serverless PDF exporter for JupyterLite based on WebAssembly distributions of [Pandoc](https://pandoc.org/app) and [Typst](https://typst.org/). This JupyterLite extension registers a
-PDF exporter with [JupyterLite's `INbConvertExporters` interface](https://jupyterlite.readthedocs.io/en/stable/howto/extensions/custom-exporters.html).
+> [!TIP]
+> While this extension was originally designed for JupyterLite in mind and is named `jupyterlite-pdf-exporter`, it is agnostic to the Jupyter environment and also works in JupyterLab 4.x, and Jupyter Notebook 7, all from a single installation. You do not need a LaTeX distribution set up or a server to export your notebooks to PDF.
+
+A serverless PDF exporter for JupyterLite, JupyterLab, and Jupyter Notebook, based on WebAssembly distributions of [Pandoc](https://pandoc.org/app) and [Typst](https://typst.org/).
+
+- This Jupyter extension registers a PDF exporter with [JupyterLite's `INbConvertExporters` interface](https://jupyterlite.readthedocs.io/en/stable/howto/extensions/custom-exporters.html).
+- In JupyterLab and Jupyter Notebook, it adds an "Export Notebook to PDF" command to the File menu and the command palette.
+
+It runs fully in the browser in a serverless fashion, so it works the same way across all three. It does not require a LaTeX distribution or a server, and it works in environments where you cannot install software, such as on a Chromebook or in a locked-down corporate environment. The PDF is downloaded to your machine at a location of your choice.
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # `jupyterlite-pdf-exporter`
 
+> [!TIP]
+> While this extension was originally designed for JupyterLite in mind and was thus named `jupyterlite-pdf-exporter`, it is agnostic to the Jupyter environment and also works in JupyterLab 4.x, and Jupyter Notebook 7, all from a single installation. You do not need a LaTeX distribution set up or a server to export your notebooks to PDF.
+
 [![Github Actions build status](https://github.com/agriyakhetarpal/jupyterlite-pdf-exporter/workflows/Build/badge.svg)](https://github.com/agriyakhetarpal/jupyterlite-pdf-exporter/actions/workflows/build.yml)
 [![Try PDF exporter in JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://agriyakhetarp.al/jupyterlite-pdf-exporter/)
 [![PyPI version](https://badge.fury.io/py/jupyterlite-pdf-exporter.svg)](https://pypi.org/project/jupyterlite-pdf-exporter/)
 
-> [!TIP]
-> While this extension was originally designed for JupyterLite in mind and is named `jupyterlite-pdf-exporter`, it is agnostic to the Jupyter environment and also works in JupyterLab 4.x, and Jupyter Notebook 7, all from a single installation. You do not need a LaTeX distribution set up or a server to export your notebooks to PDF.
+
 
 A serverless PDF exporter for JupyterLite, JupyterLab, and Jupyter Notebook, based on WebAssembly distributions of [Pandoc](https://pandoc.org/app) and [Typst](https://typst.org/).
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 [![Github Actions build status](https://github.com/agriyakhetarpal/jupyterlite-pdf-exporter/workflows/Build/badge.svg)](https://github.com/agriyakhetarpal/jupyterlite-pdf-exporter/actions/workflows/build.yml)
 [![Try PDF exporter in JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://agriyakhetarp.al/jupyterlite-pdf-exporter/)
+[![Try PDF exporter in JupyterLab on Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/agriyakhetarpal/jupyterlite-pdf-exporter/HEAD?urlpath=lab)
 [![PyPI version](https://badge.fury.io/py/jupyterlite-pdf-exporter.svg)](https://pypi.org/project/jupyterlite-pdf-exporter/)
 
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 [![Try PDF exporter in JupyterLab on Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/agriyakhetarpal/jupyterlite-pdf-exporter/HEAD?urlpath=lab)
 [![PyPI version](https://badge.fury.io/py/jupyterlite-pdf-exporter.svg)](https://pypi.org/project/jupyterlite-pdf-exporter/)
 
-
-
 A serverless PDF exporter for JupyterLite, JupyterLab, and Jupyter Notebook, based on WebAssembly distributions of [Pandoc](https://pandoc.org/app) and [Typst](https://typst.org/).
 
 - This Jupyter extension registers a PDF exporter with [JupyterLite's `INbConvertExporters` interface](https://jupyterlite.readthedocs.io/en/stable/howto/extensions/custom-exporters.html).

--- a/README.md
+++ b/README.md
@@ -46,22 +46,34 @@ and rebuild your JupyterLite distribution.
 
 ## Usage
 
-- Install this extension in your JupyterLite deployment via `pip install jupyterlite-pdf-exporter` and rebuild your JupyterLite distribution.
-- Open a notebook in JupyterLite, click on the "File" menu, and select "Save and Export Notebook As" > "PDF". The PDF file will be downloaded to your local machine at a location of your choice.
+In both JupyterLab and JupyterLite environments, the entry point to usage lives in the same place, under "File" > "Save and Export Notebook As". The exported PDF is downloaded to your machine at a location of your choice.
 
 ### Requirements
 
-- JupyterLite 0.7.0 and later
+- JupyterLite 0.7.0 and later, or JupyterLab 4.x, or Jupyter Notebook 7
 - A modern web browser with support for WebAssembly and Web Workers (e.g., Chrome, Firefox, Safari, Edge, and so on). All browsers supported by JupyterLite should work with this extension.
 - The extension relies on WebAssembly distributions of Pandoc and Typst. These distributions are quite large (over 50 MiB) and may take some time to download and initialise when the extension is first used. For a better user experience, it is recommended to use this extension in an environment with a stable and reasonably fast internet connection.
+
+### JupyterLite
+
+- Install this extension in your JupyterLite deployment via `pip install jupyterlite-pdf-exporter` and rebuild your JupyterLite distribution.
+- Open a notebook in JupyterLite, click on the "File" menu, and select "Save and Export Notebook As" > "PDF".
+  - You may also run "Save and Export Notebook: PDF" via the command palette.
+
+### In JupyterLab or Jupyter Notebook
+
+- Install this extension in your environment and open JupyterLab/Jupyter Notebook.
+- Open a notebook, then pick "File" > "Save and Export Notebook As" > "PDF (via jupyterlite-pdf-exporter)".
+  - You may also run "Save and Export Notebook: PDF (via jupyterlite-pdf-exporter)" via the command palette.
 
 ### Customising the PDFs
 
 It is also possible to change the look and feel of the exported PDF(s) through the settings.
 
-To change the settings for yourself, open the "Settings Editor" in JupyterLite from the "Settings" menu and pick "JupyterLite PDF Exporter". The form lets you set the page size, font, margins, and more. The new settings apply the next time you export a notebook. Choosing the settings per-notebook is currently not implemented.
+To change the settings for yourself, open the "Settings Editor" from the "Settings" menu in JupyterLite, JupyterLab, or Notebook 7, and pick "JupyterLite PDF Exporter". The form lets you set the page size, font, margins, and more. The new settings apply the next time you export a notebook. Choosing the settings per-notebook is currently not implemented.
 
-If you build a JupyterLite site for other people, you can set the defaults for everyone. For this, you may add an entry for `jupyterlite-pdf-exporter:plugin` to an `overrides.json` file in your build, or to the `settingsOverrides` field in your `jupyter-lite.json` file. Those values become the starting point for every user, who can still change them in their own Settings Editor.
+- If you build a JupyterLite site for other people, you can set the defaults for everyone. For JupyterLite, you may add an entry for `jupyterlite-pdf-exporter:plugin` to an `overrides.json` file in your build, or to the `settingsOverrides` field in your `jupyter-lite.json` file.
+- On JupyterLab and Jupyter Notebook, add the same `jupyterlite-pdf-exporter:plugin` entry to an `overrides.json` in your app settings directory. Those values become the starting point for every user, who can still change them in their own Settings Editor.
 
 Only the fonts that come bundled with the Typst compiler are available.
 
@@ -127,6 +139,28 @@ For further reference, navigate to the following resources:
 
 1. [JupyterLite documentation on configuration files](https://jupyterlite.readthedocs.io/en/stable/howto/configure/config_files.html)
 2. [JupyterLite documentation on settings overrides](https://jupyterlite.readthedocs.io/en/stable/howto/configure/settings.html)
+
+## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full setup. To try your local changes in JupyterLab or Jupyter Notebook, build the extension and link it into your environment:
+
+```bash
+jlpm install
+jlpm build
+jupyter labextension develop --overwrite .
+```
+
+Then start JupyterLab with `jupyter lab` or Jupyter Notebook with `jupyter notebook`. After a code change, run `jlpm build` again and refresh the browser.
+
+To try your local changes in JupyterLite, build the extension and link it into your JupyterLite build:
+
+```bash
+jlpm install
+jlpm build
+jupyter labextension develop --overwrite .
+```
+
+Then rebuild your JupyterLite distribution and open it in the browser via `jupyter lite build` and `jupyter lite serve` (or your usual JupyterLite build and serve commands). After a code change, run `jlpm build` again, rebuild your JupyterLite distribution, and refresh the browser.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ For further reference, navigate to the following resources:
 
 ## License
 
-The source code of this JupyterLite extension is licensed under the terms of the BSD-3-Clause "New" or "Revised" License (`BSD-3-Clause`; see the [LICENSE](LICENSE.txt) file for details).
+The source code is licensed under the terms of the BSD-3-Clause "New" or "Revised" License (`BSD-3-Clause`; see the [LICENSE](LICENSE.txt) file for details).
 
 > [!IMPORTANT]
-> However, the source distribution and wheel for this JupyterLite extension on PyPI are licensed under the terms of the GNU General Public License version 2.0 (GPL-2.0) or later (`GPL-2.0-or-later`). Please see the [Pandoc license file](LICENSE-PANDOC.txt) for details.
+> However, the source distribution and wheel for this extension on PyPI are licensed under the terms of the GNU General Public License version 2.0 (GPL-2.0) or later (`GPL-2.0-or-later`). Please see the [Pandoc license file](LICENSE-PANDOC.txt) for details.
 
 The WebAssembly/JavaScript distribution of Typst, `@myriaddreamin/typst-all-in-one`, is licensed under the terms of the Apache License 2.0 (`Apache-2.0`). Please see the [Typst license file](LICENSE-TYPST.txt) for details.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ A serverless PDF exporter for JupyterLite, JupyterLab, and Jupyter Notebook, bas
 
 It runs fully in the browser in a serverless fashion, so it works the same way across all three. It does not require a LaTeX distribution or a server, and it works in environments where you cannot install software, such as on a Chromebook or in a locked-down corporate environment. The PDF is downloaded to your machine at a location of your choice.
 
+## Why?
+
+The usual way to convert a notebook into a PDF is `nbconvert` driving a LaTeX distribution such as TeX Live or MiKTeX, or a headless browser via Playwright (WebPDF). These typically run on a server, and often need administrator rights to install. On a Chromebook, a managed corporate laptop, or any machine where you cannot install software easily, setting them up is frequently not an option. In JupyterLite, there is no server at all, so that route does not exist and notebooks could not be exported to PDF this way.
+
+This extension provides a different mechanism to export notebooks to PDF that runs entirely in your browser:
+
+1. [Pandoc](https://pandoc.org/), compiled to WebAssembly, converts the notebook to a [Typst](https://typst.org/) markup IR (intermediate representation).
+2. The Typst compiler, a modern typesetting system that stands in for LaTeX and is also compiled to WebAssembly, renders that IR into a PDF.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ For an overview of the licenses of all the JavaScript dependencies of this exten
 This project would not have been possible without the following open source projects:
 
 - [JupyterLite](https://jupyterlite.rtfd.io/en/latest/): A JupyterLab distribution that runs entirely in the web browser, powered by WebAssembly and Web Workers.
+- [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/): The next-generation web-based user interface for Project Jupyter, with a rich ecosystem of extensions.
+- [Jupyter Notebook](https://jupyter-notebook.readthedocs.io/): The original web-based interactive computing environment for Jupyter, which continues to be widely used and developed in its own right.
 - [Pandoc](https://pandoc.org/): A universal document converter that supports a wide variety of input and output formats, including Jupyter notebooks and PDF.
 - [Typst](https://typst.app/): A modern typesetting system that provides high-quality PDF output and a user-friendly syntax for document design.
 - [pandoc-wasm](https://www.npmjs.com/package/pandoc-wasm): A WebAssembly distribution of Pandoc that allows it to run in web browsers and other JavaScript environments.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ It runs fully in the browser in a serverless fashion, so it works the same way a
 
 ## Installation
 
-To install the extension into your JupyterLite deployment, execute:
+To install the extension into your Jupyter deployment, execute:
 
 ```bash
 pip install jupyterlite-pdf-exporter
 ```
 
-and rebuild your JupyterLite distribution.
+- For JupyterLite, rebuild your JupyterLite distribution after installing, so the extension is bundled into your site.
+- For JupyterLab or Jupyter Notebook, that is all you need. Start (or restart) the app and you should see "PDF (via jupyterlite-pdf-exporter)" in the "Save and Export Notebook As" section under the "File" menu.
 
 ## Uninstalling the extension
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,15 @@
+# Binder environment for trying the extension live in JupyterLab and Notebook 7.
+# JupyterLite is covered by the GitHub Pages demo, so this image targets the two
+# server based apps where the new "Export Notebook to PDF" command lives.
+#
+# nodejs is here so that "pip install ." can build the prebuilt labextension
+# during the Binder image build (see binder/postBuild).
+name: jupyterlite-pdf-exporter-demo
+channels:
+  - conda-forge
+dependencies:
+  - python >=3.10
+  - nodejs >=20
+  - pip
+  - jupyterlab >=4.0.0,<5
+  - notebook >=7

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Build and install the extension into the Binder image. "pip install ."
+# runs the hatch-jupyter-builder hook, which calls jlpm and build:prod, so the
+# prebuilt labextension is built from the current branch and then installed.
+set -eux
+
+python -m pip install .
+
+# Sanity check that JupyterLab sees the extension as enabled and OK.
+jupyter labextension list

--- a/lite/jupyter-lite.json
+++ b/lite/jupyter-lite.json
@@ -1,6 +1,6 @@
 {
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
-    "appName": "JupyterLite Pandoc PDF Exporter"
+    "appName": "JupyterLite PDF Exporter"
   }
 }

--- a/lite/requirements.txt
+++ b/lite/requirements.txt
@@ -1,2 +1,2 @@
-jupyterlite==0.7.1
+jupyterlite==0.7.6
 jupyterlite-pyodide-kernel==0.7.0

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     },
     "dependencies": {
         "@jupyterlab/application": "^4.5.8",
+        "@jupyterlab/apputils": "^4.6.8",
+        "@jupyterlab/mainmenu": "^4.5.8",
+        "@jupyterlab/notebook": "^4.5.8",
         "@jupyterlab/services": "^7.5.8",
         "@jupyterlab/settingregistry": "^4.5.8",
         "@jupyterlab/statusbar": "^4.5.8",

--- a/package.json
+++ b/package.json
@@ -132,8 +132,10 @@
         "webpackConfig": "./webpack.config.js",
         "sharedPackages": {
             "@jupyterlite/services": {
-                "bundled": false,
-                "singleton": true
+                "bundled": true,
+                "singleton": true,
+                "version": "0.0.0",
+                "requiredVersion": false
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
         "webpackConfig": "./webpack.config.js",
         "sharedPackages": {
             "@jupyterlite/services": {
-                "bundled": false,
+                "bundled": true,
                 "singleton": true
             }
         }

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
         "webpackConfig": "./webpack.config.js",
         "sharedPackages": {
             "@jupyterlite/services": {
-                "bundled": true,
+                "bundled": false,
                 "singleton": true
             }
         }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
     "keywords": [
         "jupyter",
         "jupyterlab",
+        "jupyterlab-extension",
         "jupyterlite",
         "jupyterlite-extension",
+        "notebook",
+        "jupyter-notebook",
         "pdf",
         "exporter",
         "pandoc",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "@jupyterlab/application": "^4.5.8",
         "@jupyterlab/apputils": "^4.6.8",
         "@jupyterlab/mainmenu": "^4.5.8",
+        "@jupyterlab/nbformat": "^4.5.8",
         "@jupyterlab/notebook": "^4.5.8",
         "@jupyterlab/services": "^7.5.8",
         "@jupyterlab/settingregistry": "^4.5.8",

--- a/src/command.ts
+++ b/src/command.ts
@@ -77,7 +77,7 @@ export const commandPlugin: JupyterFrontEndPlugin<void> = {
     app.commands.addCommand(CommandIDs.exportPdf, {
       // Inside the export submenu, we sit next to a server-side "PDF" entry,
       // so we name ourselves so the two are easy to tell apart. Elsewhere,
-      // such as the command palette, we can. use the full label.
+      // such as the command palette, we can use the full label.
       label: args =>
         args.fromExportMenu
           ? 'PDF (via jupyterlite-pdf-exporter)'

--- a/src/command.ts
+++ b/src/command.ts
@@ -10,6 +10,8 @@ import { ICommandPalette } from '@jupyterlab/apputils';
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
 
+import type { INotebookContent } from '@jupyterlab/nbformat';
+
 import { INotebookTracker } from '@jupyterlab/notebook';
 
 import { INbConvertExporters } from '@jupyterlite/services';
@@ -61,10 +63,7 @@ export const commandPlugin: JupyterFrontEndPlugin<void> = {
         if (!panel || !panel.model) {
           return;
         }
-        const notebook = panel.model.toJSON() as unknown as Record<
-          string,
-          unknown
-        >;
+        const notebook = panel.model.toJSON() as INotebookContent;
         await exportNotebookToPdf(notebook, panel.context.path);
       }
     });

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Agriya Khetarpal
+// SPDX-License-Identifier: BSD-3-Clause
+
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { ICommandPalette } from '@jupyterlab/apputils';
+
+import { IMainMenu } from '@jupyterlab/mainmenu';
+
+import { INotebookTracker } from '@jupyterlab/notebook';
+
+import { INbConvertExporters } from '@jupyterlite/services';
+
+import { exportNotebookToPdf } from './pdf';
+
+/**
+ * The command IDs used by this plugin.
+ */
+namespace CommandIDs {
+  export const exportPdf = 'jupyterlite-pdf-exporter:export-pdf';
+}
+
+/**
+ * A JupyterFrontEndPlugin that adds an "Export Notebook to PDF" command for
+ * JupyterLab and Notebook 7. It reads the active notebook and runs the same
+ * pandoc and Typst pipeline used by the JupyterLite exporter.
+ *
+ * In JupyterLite, the native "Save and Export Notebook As" menu already offers PDF
+ * export, so we skip this command there to avoid duplicating. We detect JupyterLite
+ * by asking for the INbConvertExporters token as an optional dependency. It will
+ * resolve to a value in JupyterLite and to null in JupyterLab.
+ */
+export const commandPlugin: JupyterFrontEndPlugin<void> = {
+  id: 'jupyterlite-pdf-exporter:commands',
+  description: 'Adds an "Export Notebook to PDF" command',
+  autoStart: true,
+  requires: [INotebookTracker],
+  optional: [ICommandPalette, IMainMenu, INbConvertExporters],
+  activate: (
+    app: JupyterFrontEnd,
+    tracker: INotebookTracker,
+    palette: ICommandPalette | null,
+    mainMenu: IMainMenu | null,
+    nbConvertExporters: INbConvertExporters | null
+  ): void => {
+    // JupyterLite
+    if (nbConvertExporters) {
+      return;
+    }
+
+    app.commands.addCommand(CommandIDs.exportPdf, {
+      label: 'Export Notebook to PDF',
+      caption:
+        'Export the current notebook to a PDF in the browser, using Pandoc and Typst',
+      isEnabled: () => tracker.currentWidget !== null,
+      execute: async () => {
+        const panel = tracker.currentWidget;
+        if (!panel || !panel.model) {
+          return;
+        }
+        const notebook = panel.model.toJSON() as unknown as Record<
+          string,
+          unknown
+        >;
+        await exportNotebookToPdf(notebook, panel.context.path);
+      }
+    });
+
+    if (palette) {
+      palette.addItem({
+        command: CommandIDs.exportPdf,
+        category: 'Notebook Operations'
+      });
+    }
+
+    if (mainMenu) {
+      mainMenu.fileMenu.addGroup([{ command: CommandIDs.exportPdf }], 60);
+    }
+
+    // Keep the menu and palette enable state in sync with the active notebook
+    tracker.currentChanged.connect(() => {
+      app.commands.notifyCommandChanged(CommandIDs.exportPdf);
+    });
+  }
+};

--- a/src/command.ts
+++ b/src/command.ts
@@ -16,6 +16,8 @@ import { INotebookTracker } from '@jupyterlab/notebook';
 
 import { INbConvertExporters } from '@jupyterlite/services';
 
+import { Menu } from '@lumino/widgets';
+
 import { exportNotebookToPdf } from './pdf';
 
 /**
@@ -26,9 +28,29 @@ namespace CommandIDs {
 }
 
 /**
+ * The ID of JupyterLab's "Save and Export Notebook As" submenu, declared by
+ * @jupyterlab/notebook-extension. We add our PDF command to that submenu so
+ * it sits with the other export formats, which is where JupyterLite shows
+ * its PDF entry too (just with a different mechanism).
+ */
+const EXPORT_SUBMENU_ID = 'jp-mainmenu-file-notebookexport';
+
+/**
+ * Find the "Save and Export Notebook As" submenu in JupyterLab's main menu.
+ */
+function findExportSubmenu(mainMenu: IMainMenu): Menu | null {
+  for (const item of mainMenu.fileMenu.items) {
+    if (item.type === 'submenu' && item.submenu?.id === EXPORT_SUBMENU_ID) {
+      return item.submenu;
+    }
+  }
+  return null;
+}
+
+/**
  * A JupyterFrontEndPlugin that adds an "Export Notebook to PDF" command for
- * JupyterLab and Notebook 7. It reads the active notebook and runs the same
- * pandoc and Typst pipeline used by the JupyterLite exporter.
+ * JupyterLab and Jupyter Notebook. It reads the active notebook and runs the same
+ * Pandoc and Typst pipeline used by the JupyterLite exporter.
  *
  * In JupyterLite, the native "Save and Export Notebook As" menu already offers PDF
  * export, so we skip this command there to avoid duplicating. We detect JupyterLite
@@ -54,9 +76,15 @@ export const commandPlugin: JupyterFrontEndPlugin<void> = {
     }
 
     app.commands.addCommand(CommandIDs.exportPdf, {
-      label: 'Export Notebook to PDF',
+      // Inside the export submenu, we sit next to a server-side "PDF" entry,
+      // so we name ourselves so the two are easy to tell apart. Elsewhere,
+      // such as the command palette, we can. use the full label.
+      label: args =>
+        args.fromExportMenu
+          ? 'PDF (via jupyterlite-pdf-exporter)'
+          : 'Export Notebook to PDF (via jupyterlite-pdf-exporter)',
       caption:
-        'Export the current notebook to a PDF in the browser, using Pandoc and Typst',
+        'Export the current notebook to a PDF in the browser using Pandoc and Typst, with neither a LaTeX distribution nor a server needed',
       isEnabled: () => tracker.currentWidget !== null,
       execute: async () => {
         const panel = tracker.currentWidget;
@@ -76,7 +104,13 @@ export const commandPlugin: JupyterFrontEndPlugin<void> = {
     }
 
     if (mainMenu) {
-      mainMenu.fileMenu.addGroup([{ command: CommandIDs.exportPdf }], 60);
+      const exportSubmenu = findExportSubmenu(mainMenu);
+      if (exportSubmenu) {
+        exportSubmenu.addItem({
+          command: CommandIDs.exportPdf,
+          args: { fromExportMenu: true }
+        });
+      }
     }
 
     // Keep the menu and palette enable state in sync with the active notebook

--- a/src/command.ts
+++ b/src/command.ts
@@ -39,12 +39,11 @@ const EXPORT_SUBMENU_ID = 'jp-mainmenu-file-notebookexport';
  * Find the "Save and Export Notebook As" submenu in JupyterLab's main menu.
  */
 function findExportSubmenu(mainMenu: IMainMenu): Menu | null {
-  for (const item of mainMenu.fileMenu.items) {
-    if (item.type === 'submenu' && item.submenu?.id === EXPORT_SUBMENU_ID) {
-      return item.submenu;
-    }
-  }
-  return null;
+  return (
+    mainMenu.fileMenu.items.find(
+      item => item.type === 'submenu' && item.submenu?.id === EXPORT_SUBMENU_ID
+    )?.submenu ?? null
+  );
 }
 
 /**

--- a/src/command.ts
+++ b/src/command.ts
@@ -81,7 +81,7 @@ export const commandPlugin: JupyterFrontEndPlugin<void> = {
       label: args =>
         args.fromExportMenu
           ? 'PDF (via jupyterlite-pdf-exporter)'
-          : 'Export Notebook to PDF (via jupyterlite-pdf-exporter)',
+          : 'Save and Export Notebook: PDF (via jupyterlite-pdf-exporter)',
       caption:
         'Export the current notebook to a PDF in the browser using Pandoc and Typst, with neither a LaTeX distribution nor a server needed',
       isEnabled: () => tracker.currentWidget !== null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { ServiceManagerPlugin } from '@jupyterlab/services';
 
 import { INbConvertExporters } from '@jupyterlite/services';
 
-import { PdfExporter } from './pdf';
+import { commandPlugin } from './command';
 
 import { statusBarPlugin } from './status';
 
@@ -23,9 +23,10 @@ const exporterPlugin: ServiceManagerPlugin<void> = {
     'A PDF exporter for JupyterLite based on WebAssembly distributions of Pandoc and Typst',
   autoStart: true,
   requires: [INbConvertExporters],
-  activate: (_: null, exporters: INbConvertExporters): void => {
+  activate: async (_: null, exporters: INbConvertExporters): Promise<void> => {
+    const { PdfExporter } = await import('./jupyterlite-exporter');
     exporters.register('PDF', new PdfExporter());
   }
 };
 
-export default [exporterPlugin, statusBarPlugin, settingsPlugin];
+export default [exporterPlugin, commandPlugin, statusBarPlugin, settingsPlugin];

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,16 @@ const exporterPlugin: ServiceManagerPlugin<void> = {
   description:
     'A PDF exporter for JupyterLite based on WebAssembly distributions of Pandoc and Typst',
   autoStart: true,
-  requires: [INbConvertExporters],
-  activate: async (_: null, exporters: INbConvertExporters): Promise<void> => {
+  optional: [INbConvertExporters],
+  activate: async (
+    _: null,
+    exporters: INbConvertExporters | null
+  ): Promise<void> => {
+    // INbConvertExporters is only provided in JupyterLite. In JupyterLab and Jupyter
+    // Notebook it resolves to null, so there is nothing to register here.
+    if (!exporters) {
+      return;
+    }
     const { PdfExporter } = await import('./jupyterlite-exporter');
     exporters.register('PDF', new PdfExporter());
   }

--- a/src/jupyterlite-exporter.ts
+++ b/src/jupyterlite-exporter.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Agriya Khetarpal
 // SPDX-License-Identifier: BSD-3-Clause
 
+import type { INotebookContent } from '@jupyterlab/nbformat';
+
 import type { Contents } from '@jupyterlab/services';
 
 import { BaseExporter } from '@jupyterlite/services';
@@ -28,6 +30,6 @@ export class PdfExporter extends BaseExporter {
    * @param path The path to the notebook
    */
   async export(model: Contents.IModel, path: string): Promise<void> {
-    await exportNotebookToPdf(model.content as Record<string, unknown>, path);
+    await exportNotebookToPdf(model.content as INotebookContent, path);
   }
 }

--- a/src/jupyterlite-exporter.ts
+++ b/src/jupyterlite-exporter.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Agriya Khetarpal
+// SPDX-License-Identifier: BSD-3-Clause
+
+import type { Contents } from '@jupyterlab/services';
+
+import { BaseExporter } from '@jupyterlite/services';
+
+import { exportNotebookToPdf } from './pdf';
+
+/**
+ * A JupyterLite exporter that plugs the shared PDF pipeline
+ * into JupyterLite's INbConvertExporters registry.
+ *
+ * This is the only module that imports from @jupyterlite/services, so
+ * it is loaded lazily (see src/index.ts). It must never be reached
+ * when the extension runs in JupyterLab.
+ */
+export class PdfExporter extends BaseExporter {
+  /**
+   * The MIME type of the exported format.
+   */
+  readonly mimeType = 'application/pdf';
+
+  /**
+   * Export a notebook to PDF format.
+   *
+   * @param model The notebook model to export
+   * @param path The path to the notebook
+   */
+  async export(model: Contents.IModel, path: string): Promise<void> {
+    await exportNotebookToPdf(model.content as Record<string, unknown>, path);
+  }
+}

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -41,6 +41,13 @@ let typstLoadingPromise: Promise<void> | null = null;
  * The pipeline is as follows:
  * Notebook JSON ➡️ pandoc (ipynb ➡️ typst) ➡️ Typst markup ➡️ typst-ts ➡️ PDF
  *
+ * This function should remain free of any JupyterLab or JupyterLite dependency. It
+ * takes the notebook content directly so it can be called from both the JupyterLite
+ * exporter adapter and the JupyterLab command.
+ * Note to self: preprocessNotebook edits the notebook object in place, so callers
+ * should pass a copy they own (for example the result of model.toJSON()), rather
+ * than a live model object.
+ *
  * @param notebook The notebook content (nbformat JSON) to export
  * @param path The path to the notebook, used to name the downloaded file
  */

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Agriya Khetarpal
 // SPDX-License-Identifier: BSD-3-Clause
 
+import { isCode } from '@jupyterlab/nbformat';
+
+import type {
+  IBaseOutput,
+  IMimeBundle,
+  INotebookContent
+} from '@jupyterlab/nbformat';
+
 import { pdfExportProgress } from './progress';
 
 import { buildPandocConfig, pdfExportSettings } from './settings';
@@ -37,7 +45,7 @@ let typstLoadingPromise: Promise<void> | null = null;
  * @param path The path to the notebook, used to name the downloaded file
  */
 export async function exportNotebookToPdf(
-  notebook: Record<string, unknown>,
+  notebook: INotebookContent,
   path: string
 ): Promise<void> {
   try {
@@ -181,11 +189,17 @@ async function loadTypst(): Promise<void> {
   return typstLoadingPromise;
 }
 
-type IpynbOutput = {
-  output_type: string;
-  data?: Record<string, string | string[]>;
-  [key: string]: unknown;
-};
+/**
+ * A code cell output we can rewrite in place. The nbformat IOutput union pins
+ * output_type to fixed literals on each member, which blocks reassigning it, and
+ * only some members expose data. We build on IBaseOutput (whose output_type is a
+ * plain string) and add an optional data bundle, so we can both read and rewrite
+ * output_type and data. Every nbformat IOutput is assignable to this shape, so we
+ * can safely view the outputs through it.
+ */
+interface IMutableOutput extends IBaseOutput {
+  data?: IMimeBundle;
+}
 
 /**
  * This function pre-processes a notebook object in-place before passing it to
@@ -212,34 +226,38 @@ type IpynbOutput = {
  * since the nbformat spec does not include update_display_data as a
  * stored output type and Pandoc seems to ignore it?
  */
-function preprocessNotebook(
-  notebook: Record<string, unknown>
-): Map<string, string> {
+function preprocessNotebook(notebook: INotebookContent): Map<string, string> {
   const mathMap = new Map<string, string>();
-  const cells = notebook.cells as Array<Record<string, unknown>>;
   let counter = 0;
 
-  for (const cell of cells) {
-    if (!Array.isArray(cell.outputs)) {
+  for (const cell of notebook.cells) {
+    // Only code cells carry outputs. The Array.isArray check also guards
+    // malformed code cells. I don't think this should ever happen, but
+    // Copilot was suggesting it for type safety, so here we are.
+    if (!isCode(cell) || !Array.isArray(cell.outputs)) {
       continue;
     }
 
-    for (const output of cell.outputs as IpynbOutput[]) {
-      // Defensive fix: update_display_data → display_data
+    // View the outputs through IMutableOutput, so we can rewrite output_type and
+    // the data bundle. Every nbformat IOutput is assignable to this shape.
+    for (const output of cell.outputs as IMutableOutput[]) {
       if (output.output_type === 'update_display_data') {
         output.output_type = 'display_data';
       }
 
       const data = output.data;
-      if (data?.['text/latex'] === undefined) {
+      const latex = data?.['text/latex'];
+      if (data === undefined || latex === undefined) {
         continue;
       }
 
-      const raw = (
-        Array.isArray(data['text/latex'])
-          ? data['text/latex'].join('')
-          : data['text/latex']
-      ).trim();
+      // text/latex is stored as a string or a list of strings. Anything
+      // else is not something we can turn into math, so we skip it.
+      const latexString = Array.isArray(latex) ? latex.join('') : latex;
+      if (typeof latexString !== 'string') {
+        continue;
+      }
+      const raw = latexString.trim();
 
       // IPython.display.Math wraps content in "$\displaystyle …$" (single-dollar,
       // inline delimiters). Strip the wrapper so we have the bare LaTeX expression.

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -1,10 +1,6 @@
 // Copyright (c) Agriya Khetarpal
 // SPDX-License-Identifier: BSD-3-Clause
 
-import type { Contents } from '@jupyterlab/services';
-
-import { BaseExporter } from '@jupyterlite/services';
-
 import { pdfExportProgress } from './progress';
 
 import { buildPandocConfig, pdfExportSettings } from './settings';
@@ -32,111 +28,100 @@ let typstLoaded = false;
 let typstLoadingPromise: Promise<void> | null = null;
 
 /**
- * A PDF exporter for JupyterLite notebooks using pandoc-wasm and Typst.
+ * Export a notebook to a PDF using pandoc-wasm and Typst.
  *
  * The pipeline is as follows:
  * Notebook JSON ➡️ pandoc (ipynb ➡️ typst) ➡️ Typst markup ➡️ typst-ts ➡️ PDF
+ *
+ * @param notebook The notebook content (nbformat JSON) to export
+ * @param path The path to the notebook, used to name the downloaded file
  */
-export class PdfExporter extends BaseExporter {
-  /**
-   * The MIME type of the exported format.
-   */
-  readonly mimeType = 'application/pdf';
+export async function exportNotebookToPdf(
+  notebook: Record<string, unknown>,
+  path: string
+): Promise<void> {
+  try {
+    // step 1: load both pandoc and typst in parallel on first use
+    pdfExportProgress.start('Preparing PDF export…');
+    await Promise.all([loadPandoc(), loadTypst()]);
 
-  /**
-   * Export a notebook to PDF format.
-   *
-   * @param model The notebook model to export
-   * @param path The path to the notebook
-   */
-  async export(model: Contents.IModel, path: string): Promise<void> {
-    const notebook = model.content;
+    // step 2: preprocess and convert notebook to Typst via pandoc-wasm
+    pdfExportProgress.update('Converting notebook…');
+    const mathMap = preprocessNotebook(notebook);
+    const notebookJson = JSON.stringify(notebook);
+    const files: Record<string, string | Blob> = {
+      'notebook.ipynb': notebookJson
+    };
 
-    try {
-      // step 1: load both pandoc and typst in parallel on first use
-      pdfExportProgress.start('Preparing PDF export…');
-      await Promise.all([loadPandoc(), loadTypst()]);
+    const { options, variables } = buildPandocConfig(pdfExportSettings.current);
 
-      // step 2: preprocess and convert notebook to Typst via pandoc-wasm
-      pdfExportProgress.update('Converting notebook…');
-      const mathMap = preprocessNotebook(notebook as Record<string, unknown>);
-      const notebookJson = JSON.stringify(notebook);
-      const files: Record<string, string | Blob> = {
-        'notebook.ipynb': notebookJson
-      };
+    const result = await pandocConvert!(
+      {
+        from: 'ipynb',
+        to: 'typst',
+        standalone: true,
+        'extract-media': '.',
+        'input-files': ['notebook.ipynb'],
+        ...options,
+        variables
+      },
+      null,
+      files
+    );
 
-      const { options, variables } = buildPandocConfig(
-        pdfExportSettings.current
-      );
-
-      const result = await pandocConvert!(
-        {
-          from: 'ipynb',
-          to: 'typst',
-          standalone: true,
-          'extract-media': '.',
-          'input-files': ['notebook.ipynb'],
-          ...options,
-          variables
-        },
-        null,
-        files
-      );
-
-      if (result.stderr && result.stderr.includes('ERROR')) {
-        throw new Error(`Pandoc conversion failed: ${result.stderr}`);
-      }
-
-      // step 3: splice converted Typst math back into the Typst source
-      const typstContent =
-        mathMap.size > 0
-          ? await postprocessTypst(result.stdout, mathMap)
-          : result.stdout;
-
-      // step 4: compile the Typst to a PDF
-      pdfExportProgress.update('Generating PDF…');
-      $typst.resetShadow();
-      const typstBytes = new TextEncoder().encode(typstContent);
-      $typst.mapShadow('/main.typ', typstBytes);
-
-      // We also need to map extracted media files (e.g., matplotlib plots) into Typst's filesystem
-      // TODO investigate if there's a more efficient way to pass these through without needing to go
-      // through JS memory, especially for large files
-      // TODO investigate if ipywidgets and other sorts of media work or if we need special handling for them
-      if (result.mediaFiles) {
-        for (const [filename, content] of Object.entries(result.mediaFiles)) {
-          let bytes: Uint8Array;
-          if (content instanceof Blob) {
-            bytes = new Uint8Array(await content.arrayBuffer());
-          } else if (typeof content === 'string') {
-            bytes = new TextEncoder().encode(content);
-          } else {
-            continue;
-          }
-          $typst.mapShadow('/' + filename, bytes);
-        }
-      }
-
-      const pdfData = await $typst.pdf({ mainFilePath: '/main.typ' });
-
-      // This should not really happen since we'll at least have the PDF header
-      // and at least one cell in the notebook (even if it's empty)
-      if (!pdfData || pdfData.length === 0) {
-        throw new Error('Typst produced empty PDF output');
-      }
-
-      // step 5: download the PDF in the browser
-      const pdfBlob = new Blob([pdfData.buffer as ArrayBuffer], {
-        type: 'application/pdf'
-      });
-      const filename = path.replace(/\.ipynb$/, '.pdf');
-      triggerBlobDownload(pdfBlob, filename);
-
-      pdfExportProgress.finish('PDF exported successfully');
-    } catch (error) {
-      pdfExportProgress.finish('PDF export failed');
-      throw error;
+    if (result.stderr && result.stderr.includes('ERROR')) {
+      throw new Error(`Pandoc conversion failed: ${result.stderr}`);
     }
+
+    // step 3: splice converted Typst math back into the Typst source
+    const typstContent =
+      mathMap.size > 0
+        ? await postprocessTypst(result.stdout, mathMap)
+        : result.stdout;
+
+    // step 4: compile the Typst to a PDF
+    pdfExportProgress.update('Generating PDF…');
+    $typst.resetShadow();
+    const typstBytes = new TextEncoder().encode(typstContent);
+    $typst.mapShadow('/main.typ', typstBytes);
+
+    // We also need to map extracted media files (e.g., matplotlib plots) into Typst's filesystem
+    // TODO investigate if there's a more efficient way to pass these through without needing to go
+    // through JS memory, especially for large files
+    // TODO investigate if ipywidgets and other sorts of media work or if we need special handling for them
+    if (result.mediaFiles) {
+      for (const [filename, content] of Object.entries(result.mediaFiles)) {
+        let bytes: Uint8Array;
+        if (content instanceof Blob) {
+          bytes = new Uint8Array(await content.arrayBuffer());
+        } else if (typeof content === 'string') {
+          bytes = new TextEncoder().encode(content);
+        } else {
+          continue;
+        }
+        $typst.mapShadow('/' + filename, bytes);
+      }
+    }
+
+    const pdfData = await $typst.pdf({ mainFilePath: '/main.typ' });
+
+    // This should not really happen since we'll at least have the PDF header
+    // and at least one cell in the notebook (even if it's empty)
+    if (!pdfData || pdfData.length === 0) {
+      throw new Error('Typst produced empty PDF output');
+    }
+
+    // step 5: download the PDF in the browser
+    const pdfBlob = new Blob([pdfData.buffer as ArrayBuffer], {
+      type: 'application/pdf'
+    });
+    const filename = path.replace(/\.ipynb$/, '.pdf');
+    triggerBlobDownload(pdfBlob, filename);
+
+    pdfExportProgress.finish('PDF exported successfully');
+  } catch (error) {
+    pdfExportProgress.finish('PDF export failed');
+    throw error;
   }
 }
 

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -43,10 +43,8 @@ let typstLoadingPromise: Promise<void> | null = null;
  *
  * This function should remain free of any JupyterLab or JupyterLite dependency. It
  * takes the notebook content directly so it can be called from both the JupyterLite
- * exporter adapter and the JupyterLab command.
- * Note to self: preprocessNotebook edits the notebook object in place, so callers
- * should pass a copy they own (for example the result of model.toJSON()), rather
- * than a live model object.
+ * exporter adapter and the JupyterLab command
+ *
  *
  * @param notebook The notebook content (nbformat JSON) to export
  * @param path The path to the notebook, used to name the downloaded file
@@ -62,8 +60,11 @@ export async function exportNotebookToPdf(
 
     // step 2: preprocess and convert notebook to Typst via pandoc-wasm
     pdfExportProgress.update('Converting notebook…');
-    const mathMap = preprocessNotebook(notebook);
-    const notebookJson = JSON.stringify(notebook);
+    // Note to self: preprocessNotebook rewrites outputs in place, so
+    // we work  on a copy to leave the caller's notebook untouched.
+    const working = structuredClone(notebook);
+    const mathMap = preprocessNotebook(working);
+    const notebookJson = JSON.stringify(working);
     const files: Record<string, string | Blob> = {
       'notebook.ipynb': notebookJson
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,6 +2430,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/mainmenu@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@jupyterlab/mainmenu@npm:4.5.8"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.8
+    "@jupyterlab/translation": ^4.5.8
+    "@jupyterlab/ui-components": ^4.5.8
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/commands": ^2.3.3
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/widgets": ^2.7.5
+  checksum: 0d45578e08da1fed322aba33c3408e73460bd12f382624041a6babdb9f8926d1a138edf7eca36eba5d3a242abc5e9b43e33edb7ede5f4df1cf80d1698722ae45
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/markedparser-extension@npm:^4.5.8":
   version: 4.5.8
   resolution: "@jupyterlab/markedparser-extension@npm:4.5.8"
@@ -7659,7 +7674,11 @@ __metadata:
   resolution: "jupyterlite-pdf-exporter@workspace:."
   dependencies:
     "@jupyterlab/application": ^4.5.8
+    "@jupyterlab/apputils": ^4.6.8
     "@jupyterlab/builder": ^4.5.8
+    "@jupyterlab/mainmenu": ^4.5.8
+    "@jupyterlab/nbformat": ^4.5.8
+    "@jupyterlab/notebook": ^4.5.8
     "@jupyterlab/services": ^7.5.8
     "@jupyterlab/settingregistry": ^4.5.8
     "@jupyterlab/statusbar": ^4.5.8


### PR DESCRIPTION
I have a rough idea in my head as to how this can be done, and it involves not doing anything when we are in JupyterLite (can be detected by the `INbConverters` interface), and not having a service manager plugin in JupyterLab.

Closes #25

<details><summary>Copilot-generated summary below, with manual edits 🤖</summary>
<p>

This PR significantly expands the functionality of the `jupyterlite-pdf-exporter` extension, making it compatible with JupyterLab 4.x and Jupyter Notebook 7 in addition to JupyterLite. The PDF export pipeline is now shared across all three environments, and the documentation and packaging have been updated to reflect these broader capabilities. The most notable changes are grouped below.

**Major feature: JupyterLab and Notebook 7 support**

- Added a new `commandPlugin` (`src/command.ts`) that registers an "Export Notebook to PDF" command in JupyterLab and Notebook 7, integrating with the File menu and command palette. The command uses the same in-browser PDF export pipeline as JupyterLite, without requiring a server or LaTeX installation.
- Updated dependencies and packaging (`package.json`) to include required JupyterLab packages and keywords for JupyterLab and Notebook 7 compatibility.

**Refactoring for shared PDF export pipeline**

- Refactored the PDF export logic (`src/pdf.ts`) to be environment-agnostic, so it can be used both by the JupyterLite exporter and the new JupyterLab/Notebook command.
- Moved the JupyterLite-specific exporter adapter to a new module (`src/jupyterlite-exporter.ts`), which is now loaded lazily only in JupyterLite.

**Documentation and usage improvements**

- Extensively revised the `README.md` to document support for JupyterLab and Notebook 7, clarify installation and usage instructions for all environments, and explain the motivation and technical approach.
- Added a new "Development" section to the README with instructions for local development and testing in all supported environments.

**Development and testing infrastructure**

- Added Binder configuration files (`binder/environment.yml` and `binder/postBuild`) to enable live, server-based demos and testing of the extension in JupyterLab and Notebook 7.
- Updated the JupyterLite deployment in `lite/` to the latest version.

These changes make the extension more broadly useful and easier to develop and test across the modern Jupyter ecosystem.

</p>
</details>

<details><summary>Claude Haiku 4.5 generated a summary of my Webpack config change 🤖</summary>
<p>

# Making the PDF exporter work in both JupyterLite and JupyterLab

This note records why supporting JupyterLab and Notebook 7 alongside JupyterLite is
harder than it looks, what the real blocker is, and the options we actually have. It
is written so it can be dropped into a pull request comment.

## Goal

One extension that exports a notebook to PDF (Pandoc plus Typst, fully in the browser)
in JupyterLite, JupyterLab 4.x, and Notebook 7.

## What already works in JupyterLite

- A `ServiceManagerPlugin` registers a PDF exporter through JupyterLite's
  `INbConvertExporters` token, so PDF shows up in the native "File > Save and Export
  Notebook As" menu.
- The actual conversion pipeline (`exportNotebookToPdf` in `src/pdf.ts`) has no
  dependency on JupyterLite. It takes notebook JSON and downloads a Blob.

## What we added for JupyterLab

- A normal `JupyterFrontEndPlugin` command (`src/command.ts`) that grabs the active
  notebook with `INotebookTracker` and runs the same pipeline. This part works fine in
  JupyterLab and Notebook 7 on its own.

## The blocker

It comes down to how `@jupyterlite/services` has to be shared.

1. In JupyterLite the `INbConvertExporters` token our plugin imports must be the **same
   object** that JupyterLite core provides. Lumino matches plugin tokens by object
   identity. The token must therefore resolve to the host's shared copy of
   `@jupyterlite/services`. The simplest way to guarantee that is `bundled: false`, so we
   never even have our own copy. If instead we bundle our own copy and it wins the
   singleton, the token is a different object, our `ServiceManagerPlugin` requirement is
   never satisfied, the service manager fails to initialise, and the Pyodide kernel
   connection breaks. We saw this in practice with a naive `bundled: true` whose version
   was higher than the host's. (The fix, below, is to bundle but make our copy always
   lose the singleton.)

2. But with `bundled: false`, JupyterLab has no provider for `@jupyterlite/services`.
   The moment any statically loaded module imports from it, the whole federated
   extension fails to load with:

   ```
   Error: Shared module @jupyterlite/services doesn't exist in shared scope default
   ```

3. The `ServiceManagerPlugin` has to statically import the `INbConvertExporters` token.
   In `@jupyterlab/services` a service manager plugin is typed `IPlugin<null, T>`, so
   its `activate` only receives `null` plus whatever it lists in `requires`. The only
   way to get the exporter registry is `requires: [INbConvertExporters]`, and that is a
   static import. That static import is exactly what breaks JupyterLab.

So JupyterLite needs `bundled: false` plus a static token import, and JupyterLab needs
that same static import to not exist. Those two requirements cannot both be true in one
`bundled: false` bundle.

## Why "just detect the environment and branch" does not work

This was the obvious idea, so it is worth being clear about why it fails.

- The shared module error is thrown by webpack during its "ensure shared" step, which
  runs **before any of our JavaScript executes**. An `if (isJupyterLite())` check never
  gets the chance to run, because the module never finishes loading. Detection can gate
  behaviour, but it cannot change whether a static import resolves.
- There is no runtime way to register the exporter without the token either. The public
  `NbConvert.IManager` interface has no `register` method (the registry is private),
  service manager tokens are not resolvable from the app plugin scope, and service
  manager plugins cannot be added after startup.

In short: the command (an app plugin) gates cleanly, but the JupyterLite
`INbConvertExporters` registration depends on a static import that is fatal in
JupyterLab, with no runtime escape hatch.

## The options we actually have

### Option 1: Bundle with a "always defer to the host" version (one package, keeps both menus)

Set `bundled: true` so JupyterLab has a fallback copy and loads, and `singleton: true`
so JupyterLite shares one instance. The trick is to advertise our provided copy as
version `0.0.0` and turn off the version check, so the host's real version always wins
the singleton in JupyterLite no matter what version it is, while JupyterLab uses our
bundled copy.

```json
"@jupyterlite/services": {
  "bundled": true,
  "singleton": true,
  "version": "0.0.0",
  "requiredVersion": false
}
```

- Keeps both the native JupyterLite menu and the JupyterLab command, in one package.
- We can never win the singleton, so we can never break a user's Pyodide kernel, on any
  JupyterLite version, old or new.
- Cost: a small webpack trick that needs a comment to explain it. The bundled copy is
  only the JupyterLab fallback and what we compile against, it does not have to track
  JupyterLite.

A first attempt pinned our dependency to match the JupyterLite version instead. That
worked but coupled our release to JupyterLite. Worse, an equal-version tie (we bundled
0.7.6 against a 0.7.6 host) did not reliably go to the host and broke the kernel, and a
user on an older JupyterLite than our pin would also break. The `version: "0.0.0"`
approach removes all of that.

### Option 2: Two packages (clean, keeps both menus)

Keep `jupyterlite-pdf-exporter` as the JupyterLite extension (service manager plugin,
`bundled: false`, unchanged). Ship the JupyterLab and Notebook 7 command as a separate
package, with the shared pipeline factored into a common module or a small third
package.

- No federation tricks, each package is simple and robust.
- Cost: two PyPI packages to publish and keep in sync. This is the
  `jupyterlab-serverless-pdf-exporter` idea from issue #25.

### Option 3: Unified command (one package, simplest)

Drop the service manager plugin and the `@jupyterlite/services` dependency entirely. Use
the single `INotebookTracker` command in all three environments.

- Simplest and most robust, no federation edge cases at all.
- Cost: JupyterLite no longer shows PDF inside the native "Save and Export Notebook As"
  submenu. It gets the same "Export Notebook to PDF" command instead. Same export, same
  output, different entry point.

## Summary

| Option                       | One package | Keeps native Lite menu | Main risk or cost                                             |
| ---------------------------- | ----------- | ---------------------- | ------------------------------------------------------------- |
| 1. Bundle, defer to the host | Yes         | Yes                    | A small webpack version trick that needs a comment to explain |
| 2. Two packages              | No          | Yes                    | Two packages to publish and keep in sync                      |
| 3. Unified command           | Yes         | No                     | Lite loses the native submenu entry, uses the command instead |

The pipeline, settings, status bar, and the JupyterLab command are all done and tested.

## Decision: Option 1, bundle and always defer to the host

`package.json` sets `@jupyterlite/services` to:

```json
"sharedPackages": {
  "@jupyterlite/services": {
    "bundled": true,
    "singleton": true,
    "version": "0.0.0",
    "requiredVersion": false
  }
}
```

Why each field:

- `bundled: true` gives JupyterLab a local fallback copy, so the extension loads there
  even though no host provides `@jupyterlite/services`.
- `singleton: true` keeps one shared instance in JupyterLite, which is what preserves the
  `INbConvertExporters` token identity.
- `version: "0.0.0"` is the key. With `singleton: true` webpack uses the highest version
  in the share scope. By advertising our copy as `0.0.0`, the host's real version is
  always higher and always wins in JupyterLite, for every JupyterLite version. We can
  never win the singleton, so we can never break the kernel.
- `requiredVersion: false` stops webpack from warning that the host version does not match
  the range in our `package.json`.

The JupyterLab builder passes any extra keys in `sharedPackages` straight through to the
webpack ModuleFederation `shared` config (see `merge(shared, sharedPackages)` in
`@jupyterlab/builder/lib/extensionConfig.js`), which is why `version` and
`requiredVersion` work here.

The dependency itself stays at a normal range (`^0.7.6`). That version only decides what
we compile against and what JupyterLab bundles as the fallback, it does not have to track
JupyterLite, because in JupyterLite the host copy is what actually runs.

### What this means for maintenance

This is the part that matters for a project you revisit every few months.

- You do not need to track JupyterLite's version. Bump `@jupyterlite/services` like any
  other dependency, or leave it.
- A new JupyterLite, even a major one like 0.8, cannot break the kernel through us,
  because the host always wins the singleton.
- The only thing a future JupyterLite could break is the export feature itself, if it
  changes the `BaseExporter` or `INbConvertExporters` API. In that case the JupyterLite
  PDF entry would stop working (or the build would fail to compile, which you would catch
  early), but nothing crashes at runtime and the kernel is never at risk. That is the
  normal "an upstream library changed" maintenance task, not a packaging trap.



</p>
</details> 