### PR TITLE
Serialise nested-object MIME bundle values before Pandoc conversion

### DIFF
--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -254,6 +254,25 @@ function preprocessNotebook(notebook: INotebookContent): Map<string, string> {
       }
 
       const data = output.data;
+
+      // Pandoc's IPyNB reader expects every MIME-bundle value to be a string
+      // or array of strings. Some MIME types (application/geo+json) store
+      // their payload as a nested JSON object, which makes Pandoc bail out
+      // with a confusing "expected nbformat <= 3" decoding error. Serialise
+      // any such values to a JSON string to parse the notebook safely.
+      if (data) {
+        for (const mimeType of Object.keys(data)) {
+          const value = data[mimeType];
+          if (
+            value !== null &&
+            typeof value === 'object' &&
+            !Array.isArray(value)
+          ) {
+            data[mimeType] = JSON.stringify(value);
+          }
+        }
+      }
+
       const latex = data?.['text/latex'];
       if (data === undefined || latex === undefined) {
         continue;


### PR DESCRIPTION
- Notebooks with outputs whose MIME bundle stores a nested JSON object, such as `application/geo+json` from folium/ipyleaflet maps, see #17, fail PDF exports with a confusing `"expected nbformat <= 3"` error from Pandoc's IPyNB reader, which only accepts `string` or `string[]` values per MIME type.
- `preprocessNotebook` now `JSON.stringify`s any nested-object MIME values before the notebook is handed to Pandoc, so such outputs survive the conversion safely.